### PR TITLE
Hide the extra scrollbar and enable scrolling for the navigation bar when the page overflows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -193,6 +193,10 @@
     }
 }
 
+html::-webkit-scrollbar {
+    display: none;
+}
+
 .large-dashes {
     border-top: 1px dashed rgba(75, 85, 99, 0.5);
     border-left: 2px dashed rgba(75, 85, 99, 0.5);
@@ -324,4 +328,13 @@ button {
     width: -webkit-fill-available;
     width: -moz-available;
     width: fill-available;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+}
+
+.no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 }

--- a/src/components/sidebar/DesktopNav.tsx
+++ b/src/components/sidebar/DesktopNav.tsx
@@ -167,14 +167,19 @@ export default function DesktopNav({
     const url = usePathname();
 
     return (
-        <div className={clsx('flex h-full flex-col pr-5', className)}>
+        <div
+            className={clsx(
+                'no-scrollbar flex max-h-screen flex-col overflow-y-auto pr-5',
+                className
+            )}
+        >
             <div
                 className={clsx(
                     'relative h-full bg-neutral-950 transition-all duration-300 ease-in-out',
                     collapsed ? 'w-12' : 'w-[280px]'
                 )}
             >
-                <div className="flex h-full flex-col items-center justify-between">
+                <div className="flex flex-col items-center justify-between">
                     <div className={clsx('flex w-full flex-col gap-5')}>
                         <motion.div
                             className="relative overflow-hidden"


### PR DESCRIPTION
## Describe your changes

This PR hide the extra scrollbar and enable scrolling for the navigation bar when the page overflows

## Testing steps 

https://github.com/user-attachments/assets/2d9d1af7-fd5b-4134-8c0f-c47bc3329c5b

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
