### PR TITLE
Add R2 attachment handling and mention mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ DISCORD_INGEST_SECRET=<long random string>
 
 # Optional. In-memory requests per minute per server instance (default 120).
 # DISCORD_INGEST_RATE_LIMIT_PER_MINUTE=120
+
+# Optional. Set to "true" to rehost Discord attachments into Cloudflare R2
+# during webhook ingest. Requires all R2 vars below.
+# DISCORD_ATTACHMENT_REHOST_ENABLED=true
+
+# Required when DISCORD_ATTACHMENT_REHOST_ENABLED=true.
+# R2 endpoint + credentials + bucket name.
+# R2_ENDPOINT=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET_NAME=
+# R2_PUBLIC_DOMAIN=
 ```
 
 ## Running the application

--- a/src/app/(auth)/announcements/page.tsx
+++ b/src/app/(auth)/announcements/page.tsx
@@ -16,6 +16,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input/input';
 import { ToastWithButton } from '@/components/ui/ToastWithButton';
 import AnnouncementRow from '@/components/announcements/AnnouncementRow';
+import {
+    mentionDisplaySearchText,
+    normalizeDiscordContentMentions,
+} from '@/lib/discord/mentions';
 import { eventDiscordUrlForStatus } from '@/lib/eventDiscord';
 import { useWindowSize } from '@/lib/useWindowSize';
 import { trpc } from '@/trpc/client';
@@ -35,6 +39,22 @@ const FEED_BP = {
         '@announcements:col-span-4 @announcements:min-h-0 @announcements:pb-0',
     sideCardBody: '@announcements:min-h-0',
 } as const;
+
+function announcementSearchText(a: AnnouncementWithAttachments): string {
+    const normalizedBody = normalizeDiscordContentMentions(
+        a.content,
+        a.mentionMetadata
+    );
+    const mentionText = mentionDisplaySearchText(a.mentionMetadata);
+    const attachmentNames = a.attachments
+        .map((attachment) => attachment.filename ?? '')
+        .filter(Boolean)
+        .join(' ');
+
+    return [normalizedBody, mentionText, attachmentNames]
+        .join(' ')
+        .toLowerCase();
+}
 
 export default function AnnouncementsPage() {
     // Two-state search:
@@ -62,7 +82,9 @@ export default function AnnouncementsPage() {
     const filtered = useMemo(() => {
         const q = query.trim().toLowerCase();
         if (!q) return announcements;
-        return announcements.filter((a) => a.content.toLowerCase().includes(q));
+        return announcements.filter((a) =>
+            announcementSearchText(a).includes(q)
+        );
     }, [announcements, query]);
 
     const sortedDesc = useMemo(

--- a/src/app/api/webhooks/discord/route.ts
+++ b/src/app/api/webhooks/discord/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { databaseClient } from '@/db/client';
+import { rehostDiscordAttachmentIfEnabled } from '@/lib/discord/attachmentRehost';
 import {
     announcementAttachments,
     announcementChannelMappings,
@@ -132,16 +133,55 @@ async function findAnnouncementForDelete(
 }
 
 function buildAttachmentRows(announcementId: number, payload: IngestPayload) {
-    return payload.attachments.map((attachment, index) => ({
-        announcementId,
-        sourceUrl: attachment.url,
-        filename: attachment.filename ?? null,
-        contentType: attachment.contentType ?? null,
-        sizeBytes: attachment.sizeBytes ?? null,
-        width: attachment.width ?? null,
-        height: attachment.height ?? null,
-        position: index,
-    }));
+    return Promise.all(
+        payload.attachments.map(async (attachment, index) => {
+            let rehosted: Awaited<
+                ReturnType<typeof rehostDiscordAttachmentIfEnabled>
+            > = null;
+
+            try {
+                rehosted = await rehostDiscordAttachmentIfEnabled({
+                    sourceUrl: attachment.url,
+                    guildId: payload.guildId,
+                    channelId: payload.channelId,
+                    messageId: payload.messageId,
+                    position: index,
+                    filename: attachment.filename,
+                    contentType: attachment.contentType,
+                });
+            } catch (error) {
+                ingestLog({
+                    method: 'POST',
+                    outcome: 'attachment_rehost_failed',
+                    messageId: payload.messageId,
+                    channelId: payload.channelId,
+                    guildId: payload.guildId,
+                    position: index,
+                    errorName:
+                        error instanceof Error ? error.name : 'unknown_error',
+                    errorMessage:
+                        error instanceof Error
+                            ? error.message
+                            : 'unknown error while rehosting attachment',
+                });
+            }
+
+            return {
+                announcementId,
+                sourceUrl: attachment.url,
+                storedUrl: rehosted?.storedUrl ?? null,
+                storageProvider: rehosted?.storageProvider ?? null,
+                storageKey: rehosted?.storageKey ?? null,
+                uploadedAt: rehosted?.uploadedAt ?? null,
+                filename: attachment.filename ?? null,
+                contentType: attachment.contentType ?? null,
+                sizeBytes: attachment.sizeBytes ?? null,
+                width: attachment.width ?? null,
+                height: attachment.height ?? null,
+                position: index,
+            };
+        })
+    );
 }
 
 export async function POST(request: NextRequest) {
@@ -262,6 +302,7 @@ export async function POST(request: NextRequest) {
                     .update(announcements)
                     .set({
                         content: payload.content,
+                        mentionMetadata: payload.mentions,
                         lastEditedAt: editedAt,
                         rawPayload: payload.rawPayload ?? null,
                         updatedAt: new Date(),
@@ -275,9 +316,13 @@ export async function POST(request: NextRequest) {
                     );
 
                 if (payload.attachments.length > 0) {
+                    const attachmentRows = await buildAttachmentRows(
+                        existing.id,
+                        payload
+                    );
                     await tx
                         .insert(announcementAttachments)
-                        .values(buildAttachmentRows(existing.id, payload));
+                        .values(attachmentRows);
                 }
             });
 
@@ -357,6 +402,7 @@ export async function POST(request: NextRequest) {
                     sourceAuthorId: payload.authorId,
                     idempotencyKey,
                     content: payload.content,
+                    mentionMetadata: payload.mentions,
                     rawPayload: payload.rawPayload ?? null,
                     sourceTimestamp: new Date(payload.timestamp),
                     lastEditedAt: editedAt,
@@ -367,9 +413,11 @@ export async function POST(request: NextRequest) {
                 });
 
             if (payload.attachments.length > 0) {
-                await tx
-                    .insert(announcementAttachments)
-                    .values(buildAttachmentRows(row.id, payload));
+                const attachmentRows = await buildAttachmentRows(
+                    row.id,
+                    payload
+                );
+                await tx.insert(announcementAttachments).values(attachmentRows);
             }
 
             return row;

--- a/src/components/announcements/AnnouncementRow.tsx
+++ b/src/components/announcements/AnnouncementRow.tsx
@@ -16,6 +16,7 @@ import dayjs from 'dayjs';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import type { AnnouncementWithAttachments } from '@/app/(auth)/ClientContext';
+import { normalizeDiscordContentMentions } from '@/lib/discord/mentions';
 
 // max # of image attachments rendered
 export const MAX_IMAGES_PER_ANNOUNCEMENT = 2;
@@ -139,7 +140,11 @@ export default function AnnouncementRow({
     flash,
 }: AnnouncementRowProps) {
     const sourceTime = toSourceDate(a.sourceTimestamp);
-    const trimmed = a.content.trim();
+    const normalizedContent = normalizeDiscordContentMentions(
+        a.content,
+        a.mentionMetadata
+    );
+    const trimmed = normalizedContent.trim();
     const [expanded, setExpanded] = useState(false);
     const [hasOverflow, setHasOverflow] = useState(false);
     const [jumpRevealed, setJumpRevealed] = useState(false);
@@ -276,7 +281,10 @@ export default function AnnouncementRow({
                                     {imageAttachments.map((att) => (
                                         <li key={att.id}>
                                             <a
-                                                href={att.sourceUrl}
+                                                href={
+                                                    att.storedUrl ??
+                                                    att.sourceUrl
+                                                }
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 className="block overflow-hidden rounded-lg border border-neutral-700/50 bg-neutral-900/40 md:cursor-zoom-in"
@@ -291,7 +299,10 @@ export default function AnnouncementRow({
                                             >
                                                 {/* eslint-disable-next-line @next/next/no-img-element */}
                                                 <img
-                                                    src={att.sourceUrl}
+                                                    src={
+                                                        att.storedUrl ??
+                                                        att.sourceUrl
+                                                    }
                                                     alt={
                                                         att.filename ??
                                                         'Announcement image'
@@ -317,14 +328,19 @@ export default function AnnouncementRow({
                                 {imageAttachments.map((att) => (
                                     <li key={att.id}>
                                         <a
-                                            href={att.sourceUrl}
+                                            href={
+                                                att.storedUrl ?? att.sourceUrl
+                                            }
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             className="block overflow-hidden rounded-lg border border-neutral-700/50 bg-neutral-900/40"
                                         >
                                             {/* eslint-disable-next-line @next/next/no-img-element */}
                                             <img
-                                                src={att.sourceUrl}
+                                                src={
+                                                    att.storedUrl ??
+                                                    att.sourceUrl
+                                                }
                                                 alt={
                                                     att.filename ??
                                                     'Announcement image'
@@ -352,7 +368,7 @@ export default function AnnouncementRow({
                             {otherAttachments.map((att) => (
                                 <li key={att.id}>
                                     <a
-                                        href={att.sourceUrl}
+                                        href={att.storedUrl ?? att.sourceUrl}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="text-brand-400 hover:text-brand-300 underline-offset-2 hover:underline"

--- a/src/db/schema/announcements.ts
+++ b/src/db/schema/announcements.ts
@@ -73,7 +73,6 @@ export const announcementAttachments = pgTable(
         announcementId: integer('announcement_id')
             .notNull()
             .references(() => announcements.id, { onDelete: 'cascade' }),
-        // TODO: Discord CDN URLs expire after a while so probably find a way to mirror to another CDN or something
         sourceUrl: text('source_url').notNull(),
         storedUrl: text('stored_url'),
         storageProvider: varchar('storage_provider', { length: 32 }),

--- a/src/db/schema/announcements.ts
+++ b/src/db/schema/announcements.ts
@@ -35,6 +35,9 @@ export const announcements = pgTable(
         rawPayload: jsonb('raw_payload')
             .$type<Record<string, unknown> | null>()
             .default(null),
+        mentionMetadata: jsonb('mention_metadata')
+            .$type<DiscordMentionMetadata | null>()
+            .default(null),
         sourceTimestamp: timestamp('source_timestamp', {
             mode: 'date',
             withTimezone: true,
@@ -72,6 +75,13 @@ export const announcementAttachments = pgTable(
             .references(() => announcements.id, { onDelete: 'cascade' }),
         // TODO: Discord CDN URLs expire after a while so probably find a way to mirror to another CDN or something
         sourceUrl: text('source_url').notNull(),
+        storedUrl: text('stored_url'),
+        storageProvider: varchar('storage_provider', { length: 32 }),
+        storageKey: text('storage_key'),
+        uploadedAt: timestamp('uploaded_at', {
+            mode: 'date',
+            withTimezone: true,
+        }),
         filename: varchar('filename', { length: 256 }),
         contentType: varchar('content_type', { length: 128 }),
         sizeBytes: integer('size_bytes'),
@@ -120,6 +130,30 @@ export const ingestDiscordAttachmentSchema = z.object({
     height: z.number().int().nonnegative().nullable().optional(),
 });
 
+export const discordMentionUserSchema = z.object({
+    displayName: z.string().min(1),
+    username: z.string().min(1),
+});
+
+export const discordMentionRoleSchema = z.object({
+    name: z.string().min(1),
+});
+
+export const discordMentionChannelSchema = z.object({
+    name: z.string().min(1),
+    type: z.number().int(),
+});
+
+export const discordMentionMetadataSchema = z.object({
+    users: z.record(z.string().min(1), discordMentionUserSchema),
+    roles: z.record(z.string().min(1), discordMentionRoleSchema),
+    channels: z.record(z.string().min(1), discordMentionChannelSchema),
+});
+
+export type DiscordMentionMetadata = z.infer<
+    typeof discordMentionMetadataSchema
+>;
+
 export const ingestDiscordAnnouncementSchema = z
     .object({
         channelId: z.string().min(1),
@@ -137,6 +171,9 @@ export const ingestDiscordAnnouncementSchema = z
             .array(ingestDiscordAttachmentSchema)
             .optional()
             .default([]),
+        mentions: discordMentionMetadataSchema
+            .optional()
+            .default({ users: {}, roles: {}, channels: {} }),
         idempotencyKey: z.string().min(1).optional(),
         rawPayload: z.record(z.unknown()).optional(),
     })

--- a/src/lib/discord/attachmentRehost.ts
+++ b/src/lib/discord/attachmentRehost.ts
@@ -1,0 +1,169 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import mime from 'mime-types';
+
+const DISCORD_ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024;
+const ATTACHMENT_FETCH_TIMEOUT_MS = 15_000;
+
+type DiscordR2Config = {
+    endpoint: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+    bucketName: string;
+    publicBaseUrl: string;
+};
+
+export type RehostedAttachment = {
+    storedUrl: string;
+    storageProvider: 'r2';
+    storageKey: string;
+    uploadedAt: Date;
+};
+
+let cachedR2Client: S3Client | null = null;
+
+function maybeGetDiscordR2Config(): DiscordR2Config | null {
+    if (process.env.DISCORD_ATTACHMENT_REHOST_ENABLED !== 'true') {
+        return null;
+    }
+
+    const endpoint = process.env.R2_ENDPOINT?.trim();
+    const accessKeyId = process.env.R2_ACCESS_KEY_ID?.trim();
+    const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY?.trim();
+    const bucketName = process.env.R2_BUCKET_NAME?.trim();
+    const publicBaseUrl =
+        process.env.R2_PUBLIC_DOMAIN?.trim() ??
+        process.env.DISCORD_ATTACHMENT_R2_PUBLIC_BASE_URL?.trim() ??
+        process.env.R2_PUBLIC_BASE_URL?.trim();
+
+    if (
+        !endpoint ||
+        !accessKeyId ||
+        !secretAccessKey ||
+        !bucketName ||
+        !publicBaseUrl
+    ) {
+        return null;
+    }
+
+    return {
+        endpoint,
+        accessKeyId,
+        secretAccessKey,
+        bucketName,
+        publicBaseUrl: publicBaseUrl.replace(/\/+$/, ''),
+    };
+}
+
+function getR2Client(config: DiscordR2Config): S3Client {
+    if (!cachedR2Client) {
+        cachedR2Client = new S3Client({
+            region: 'auto',
+            endpoint: config.endpoint,
+            credentials: {
+                accessKeyId: config.accessKeyId,
+                secretAccessKey: config.secretAccessKey,
+            },
+        });
+    }
+    return cachedR2Client;
+}
+
+function sanitizeFilename(name: string): string {
+    const cleaned = name
+        .trim()
+        .replace(/[^\w.\-]+/g, '_')
+        .replace(/_+/g, '_');
+    return cleaned.length > 0 ? cleaned.slice(0, 128) : 'attachment';
+}
+
+function deriveFilename(
+    sourceUrl: string,
+    explicitFilename: string | null | undefined,
+    fallbackIndex: number
+): string {
+    if (explicitFilename?.trim()) {
+        return sanitizeFilename(explicitFilename);
+    }
+
+    try {
+        const parsed = new URL(sourceUrl);
+        const fromPath = parsed.pathname.split('/').pop();
+        if (fromPath) {
+            return sanitizeFilename(fromPath);
+        }
+    } catch {
+        // ignore invalid URL here; upload path will still be deterministic.
+    }
+
+    return `attachment-${fallbackIndex}`;
+}
+
+function encodeStorageKeyForUrl(storageKey: string): string {
+    return storageKey.split('/').map(encodeURIComponent).join('/');
+}
+
+export async function rehostDiscordAttachmentIfEnabled(args: {
+    sourceUrl: string;
+    guildId: string;
+    channelId: string;
+    messageId: string;
+    position: number;
+    filename?: string | null;
+    contentType?: string | null;
+}): Promise<RehostedAttachment | null> {
+    const config = maybeGetDiscordR2Config();
+    if (!config) {
+        return null;
+    }
+
+    const attachmentFileName = deriveFilename(
+        args.sourceUrl,
+        args.filename,
+        args.position
+    );
+    const storageKey =
+        `discord-announcements/${args.guildId}/${args.channelId}/${args.messageId}/` +
+        `${args.position}-${attachmentFileName}`;
+
+    const response = await fetch(args.sourceUrl, {
+        signal: AbortSignal.timeout(ATTACHMENT_FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch Discord attachment (${response.status} ${response.statusText})`
+        );
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.length > DISCORD_ATTACHMENT_MAX_BYTES) {
+        throw new Error(
+            `Attachment exceeds max rehost size (${buffer.length} bytes)`
+        );
+    }
+
+    const guessedMime =
+        (args.contentType && args.contentType.trim()) ||
+        response.headers.get('content-type') ||
+        mime.lookup(attachmentFileName) ||
+        'application/octet-stream';
+
+    const client = getR2Client(config);
+    await client.send(
+        new PutObjectCommand({
+            Bucket: config.bucketName,
+            Key: storageKey,
+            Body: buffer,
+            ContentType: guessedMime,
+        })
+    );
+
+    const uploadedAt = new Date();
+
+    return {
+        storedUrl: `${config.publicBaseUrl}/${encodeStorageKeyForUrl(storageKey)}`,
+        storageProvider: 'r2',
+        storageKey,
+        uploadedAt,
+    };
+}

--- a/src/lib/discord/mentions.ts
+++ b/src/lib/discord/mentions.ts
@@ -1,0 +1,105 @@
+type MentionUser = {
+    displayName: string;
+    username: string;
+};
+
+type MentionRole = {
+    name: string;
+};
+
+type MentionChannel = {
+    name: string;
+    type: number;
+};
+
+export type DiscordMentionMetadata = {
+    users: Record<string, MentionUser>;
+    roles: Record<string, MentionRole>;
+    channels: Record<string, MentionChannel>;
+};
+
+const USER_MENTION_RE = /<@!?(\d+)>/g;
+const ROLE_MENTION_RE = /<@&(\d+)>/g;
+const CHANNEL_MENTION_RE = /<#(\d+)>/g;
+
+function escapeInlineMarkdown(text: string): string {
+    return text.replace(/([\\`*_[\]()~>#+\-=|{}.!])/g, '\\$1');
+}
+
+function normalizeUserMention(
+    userId: string,
+    mentions: DiscordMentionMetadata | null | undefined
+): string {
+    const user = mentions?.users?.[userId];
+    if (!user) {
+        return `@unknown-user-${userId}`;
+    }
+
+    const preferredName =
+        user.displayName.trim() || user.username.trim() || `user-${userId}`;
+    return `@${escapeInlineMarkdown(preferredName)}`;
+}
+
+function normalizeRoleMention(
+    roleId: string,
+    mentions: DiscordMentionMetadata | null | undefined
+): string {
+    const role = mentions?.roles?.[roleId];
+    if (!role) {
+        return `@unknown-role-${roleId}`;
+    }
+    return `@${escapeInlineMarkdown(role.name.trim() || `role-${roleId}`)}`;
+}
+
+function normalizeChannelMention(
+    channelId: string,
+    mentions: DiscordMentionMetadata | null | undefined
+): string {
+    const channel = mentions?.channels?.[channelId];
+    if (!channel) {
+        return `#unknown-channel-${channelId}`;
+    }
+    return `#${escapeInlineMarkdown(
+        channel.name.trim() || `channel-${channelId}`
+    )}`;
+}
+
+export function normalizeDiscordContentMentions(
+    content: string,
+    mentions: DiscordMentionMetadata | null | undefined
+): string {
+    if (!content) {
+        return '';
+    }
+
+    return content
+        .replace(USER_MENTION_RE, (_, userId: string) =>
+            normalizeUserMention(userId, mentions)
+        )
+        .replace(ROLE_MENTION_RE, (_, roleId: string) =>
+            normalizeRoleMention(roleId, mentions)
+        )
+        .replace(CHANNEL_MENTION_RE, (_, channelId: string) =>
+            normalizeChannelMention(channelId, mentions)
+        );
+}
+
+export function mentionDisplaySearchText(
+    mentions: DiscordMentionMetadata | null | undefined
+): string {
+    if (!mentions) {
+        return '';
+    }
+
+    const users = Object.values(mentions.users ?? {})
+        .flatMap((user) => [user.displayName, user.username])
+        .join(' ');
+    const roles = Object.values(mentions.roles ?? {})
+        .map((role) => role.name)
+        .join(' ');
+    const channels = Object.values(mentions.channels ?? {})
+        .map((channel) => channel.name)
+        .join(' ');
+
+    return [users, roles, channels].join(' ').trim();
+}


### PR DESCRIPTION
- Add capability to store announcement attachments in R2
  - Add `DISCORD_ATTACHMENT_REHOST_ENABLED` env flag
- Add handling of role, channel, and user mentions with normalization