### PR TITLE
Submission page issues

### DIFF
--- a/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
+++ b/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
@@ -14,14 +14,23 @@ import {
 } from '@/components/application_components/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { getFileSize } from '@/components/ui/FileUpload/FileUpload';
-import { toast } from '@/hooks/use-toast';
 import { submitProject } from '@/lib/blobs';
 import { isSubmissionWindowOpen } from '@/lib/submissionWindow';
 import { trpc } from '@/trpc/client';
 import ProjectSubmissionSuccess from '@/app/(auth)/(team)/teamComponents/submit/ProjectSubmissionSuccess';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+
+/** detect window-closed errors from `/api/blob/project` and `submitSubmission`. */
+function isSubmissionWindowClosedError(message: string) {
+    return (
+        // error messages
+        message.includes('open submission window') ||
+        message.includes('submission window')
+    );
+}
 const localAppResponseAtom = atomWithStorage('submit_response', {
     hackathonId: -1,
     email: '',
@@ -91,8 +100,9 @@ export function SubmitFormCard({
     teamPictureUrl?: string | null;
 }) {
     const submitData = useAtomValue(submitWithLocalAtom);
-    const hackathon = useAtomValue(hackathonAtom);
     const setCurrentTeam = useSetAtom(currentTeamAtom);
+    const router = useRouter();
+    const utils = trpc.useUtils();
     const [progressMsg, setProgress] = useState('');
     const [projectSubmitted, setProjectSubmitted] = useState(false);
 
@@ -107,48 +117,52 @@ export function SubmitFormCard({
 
     const submitSubmission = trpc.submissions.submitSubmission.useMutation();
 
+    function rejectClosedWindow() {
+        router.refresh();
+        throw new Error(
+            'Submissions are only accepted during the open submission window.'
+        );
+    }
+
     async function submit() {
+        const activeHackathon =
+            await utils.hackathons.getActiveHackathon.fetch();
+
         if (
-            !hackathon ||
+            !activeHackathon ||
             !isSubmissionWindowOpen(
                 Date.now(),
-                hackathon.submissionOpen?.toDate() ?? null,
-                hackathon.submissionDeadline.toDate()
+                activeHackathon.submissionOpen != null
+                    ? new Date(activeHackathon.submissionOpen)
+                    : null,
+                new Date(activeHackathon.submissionDeadline)
             )
         ) {
-            const message =
-                'Submissions are only accepted during the open submission window.';
-            setProgress(message);
-            toast({
-                title: 'Submission failed',
-                description: message,
-                variant: 'error',
-            });
-            throw new Error(message);
+            rejectClosedWindow();
         }
 
-        setProgress('Starting uploads...');
-        const processedPage = await processResponseForServer(
-            submitData.pages,
-            async (filename, file) => {
-                const blob = await submitProject({
-                    fileName: filename,
-                    fileContent: file,
-                    onUploadProgress: (e) => {
-                        setProgress(
-                            `Uploading file: ${file.name}(${getFileSize(file.size)}) ${e.percentage}%`
-                        );
-                    },
-                    contentType: file.type,
-                    teamId,
-                });
-                return blob.url;
-            }
-        );
-
-        setProgress('submitting other responses...');
-        const response = getResponseMap(processedPage);
         try {
+            setProgress('Starting uploads...');
+            const processedPage = await processResponseForServer(
+                submitData.pages,
+                async (filename, file) => {
+                    const blob = await submitProject({
+                        fileName: filename,
+                        fileContent: file,
+                        onUploadProgress: (e) => {
+                            setProgress(
+                                `Uploading file: ${file.name}(${getFileSize(file.size)}) ${e.percentage}%`
+                            );
+                        },
+                        contentType: file.type,
+                        teamId,
+                    });
+                    return blob.url;
+                }
+            );
+
+            setProgress('submitting other responses...');
+            const response = getResponseMap(processedPage);
             await submitSubmission.mutateAsync({
                 teamId,
                 hackathonId: submitData.id,
@@ -158,13 +172,16 @@ export function SubmitFormCard({
             setProjectSubmitted(true);
         } catch (error) {
             console.error('Failed to submit project:', error);
-            const message = 'Failed to submit project. Please try again.';
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : 'Failed to submit project. Please try again.';
+
+            if (isSubmissionWindowClosedError(message)) {
+                rejectClosedWindow();
+            }
+
             setProgress(message);
-            toast({
-                title: 'Submission failed',
-                description: message,
-                variant: 'error',
-            });
             throw error instanceof Error ? error : new Error(message);
         }
     }

--- a/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
+++ b/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
@@ -14,7 +14,9 @@ import {
 } from '@/components/application_components/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { getFileSize } from '@/components/ui/FileUpload/FileUpload';
+import { toast } from '@/hooks/use-toast';
 import { submitProject } from '@/lib/blobs';
+import { isSubmissionWindowOpen } from '@/lib/submissionWindow';
 import { trpc } from '@/trpc/client';
 import ProjectSubmissionSuccess from '@/app/(auth)/(team)/teamComponents/submit/ProjectSubmissionSuccess';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
@@ -89,6 +91,7 @@ export function SubmitFormCard({
     teamPictureUrl?: string | null;
 }) {
     const submitData = useAtomValue(submitWithLocalAtom);
+    const hackathon = useAtomValue(hackathonAtom);
     const setCurrentTeam = useSetAtom(currentTeamAtom);
     const [progressMsg, setProgress] = useState('');
     const [projectSubmitted, setProjectSubmitted] = useState(false);
@@ -105,6 +108,25 @@ export function SubmitFormCard({
     const submitSubmission = trpc.submissions.submitSubmission.useMutation();
 
     async function submit() {
+        if (
+            !hackathon ||
+            !isSubmissionWindowOpen(
+                Date.now(),
+                hackathon.submissionOpen?.toDate() ?? null,
+                hackathon.submissionDeadline.toDate()
+            )
+        ) {
+            const message =
+                'Submissions are only accepted during the open submission window.';
+            setProgress(message);
+            toast({
+                title: 'Submission failed',
+                description: message,
+                variant: 'error',
+            });
+            throw new Error(message);
+        }
+
         setProgress('Starting uploads...');
         const processedPage = await processResponseForServer(
             submitData.pages,
@@ -136,7 +158,14 @@ export function SubmitFormCard({
             setProjectSubmitted(true);
         } catch (error) {
             console.error('Failed to submit project:', error);
-            setProgress('Failed to submit project. Please try again.');
+            const message = 'Failed to submit project. Please try again.';
+            setProgress(message);
+            toast({
+                title: 'Submission failed',
+                description: message,
+                variant: 'error',
+            });
+            throw error instanceof Error ? error : new Error(message);
         }
     }
 

--- a/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
+++ b/src/app/(auth)/(team)/teamComponents/InTeam/SubmitFormCard.tsx
@@ -23,14 +23,6 @@ import { atomWithStorage } from 'jotai/utils';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-/** detect window-closed errors from `/api/blob/project` and `submitSubmission`. */
-function isSubmissionWindowClosedError(message: string) {
-    return (
-        // error messages
-        message.includes('open submission window') ||
-        message.includes('submission window')
-    );
-}
 const localAppResponseAtom = atomWithStorage('submit_response', {
     hackathonId: -1,
     email: '',
@@ -124,20 +116,23 @@ export function SubmitFormCard({
         );
     }
 
-    async function submit() {
+    async function isActiveSubmissionWindowOpen() {
         const activeHackathon =
             await utils.hackathons.getActiveHackathon.fetch();
 
-        if (
-            !activeHackathon ||
-            !isSubmissionWindowOpen(
-                Date.now(),
-                activeHackathon.submissionOpen != null
-                    ? new Date(activeHackathon.submissionOpen)
-                    : null,
-                new Date(activeHackathon.submissionDeadline)
-            )
-        ) {
+        if (!activeHackathon) return false;
+
+        return isSubmissionWindowOpen(
+            Date.now(),
+            activeHackathon.submissionOpen != null
+                ? new Date(activeHackathon.submissionOpen)
+                : null,
+            new Date(activeHackathon.submissionDeadline)
+        );
+    }
+
+    async function submit() {
+        if (!(await isActiveSubmissionWindowOpen())) {
             rejectClosedWindow();
         }
 
@@ -172,15 +167,15 @@ export function SubmitFormCard({
             setProjectSubmitted(true);
         } catch (error) {
             console.error('Failed to submit project:', error);
+
+            if (!(await isActiveSubmissionWindowOpen())) {
+                rejectClosedWindow();
+            }
+
             const message =
                 error instanceof Error
                     ? error.message
                     : 'Failed to submit project. Please try again.';
-
-            if (isSubmissionWindowClosedError(message)) {
-                rejectClosedWindow();
-            }
-
             setProgress(message);
             throw error instanceof Error ? error : new Error(message);
         }

--- a/src/app/api/blob/project/route.ts
+++ b/src/app/api/blob/project/route.ts
@@ -1,6 +1,9 @@
+import { hackathons } from '@/db/schema/hackathons';
 import { checkUserInTeam } from '@/db/schema/members';
+import { isSubmissionWindowOpen } from '@/lib/submissionWindow';
 import { getUserData } from '@/server/routers/usersRouter';
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
+import { asc, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { ClientPayload } from '../ClientPayload';
 
@@ -31,6 +34,29 @@ export async function POST(request: Request): Promise<NextResponse> {
                 }
 
                 checkUserInTeam(user.id, teamId);
+
+                const [activeHackathon] = await databaseClient
+                    .select({
+                        submissionOpen: hackathons.submissionOpen,
+                        submissionDeadline: hackathons.submissionDeadline,
+                    })
+                    .from(hackathons)
+                    .where(eq(hackathons.isActive, true))
+                    .orderBy(asc(hackathons.startDate))
+                    .limit(1);
+
+                if (
+                    !activeHackathon ||
+                    !isSubmissionWindowOpen(
+                        Date.now(),
+                        activeHackathon.submissionOpen,
+                        activeHackathon.submissionDeadline
+                    )
+                ) {
+                    throw new Error(
+                        'Submissions are only accepted during the open submission window.'
+                    );
+                }
 
                 return {
                     allowedContentTypes: [

--- a/src/components/application_components/ReviewApplicationDialog.tsx
+++ b/src/components/application_components/ReviewApplicationDialog.tsx
@@ -46,6 +46,7 @@ export default function ReviewApplicationDialog({
         } catch (error) {
             console.error('Submission error:', error);
             setSubmitted(false);
+            closeDialog();
         }
     };
 


### PR DESCRIPTION
## Describe your changes
Fixes project submission when users keep a stale /team/submit tab open after the deadline closes.
- `SubmitFormCard` checks the active hackathon submission window (fresh from server) before uploads and again on failure.
- `/api/blob/project` blocks Vercel Blob upload tokens when the submission window is closed

## Testing steps 
- With` /team/submit `open, insert your project description and upload your files (required)
- Set `submission_deadline` to the past in Drizzle Studio, stay on /team/submit, click Submit submission 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
