### PR TITLE
add hackathon stats pipeline

### DIFF
--- a/src/app/(auth)/(sponsor)/statistics/page.tsx
+++ b/src/app/(auth)/(sponsor)/statistics/page.tsx
@@ -1,264 +1,60 @@
 'use client';
 
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import {
-    PieChart as RechartsPieChart,
-    Pie as RechartsPie,
-    Tooltip as RechartsTooltip,
-    Legend,
-    ResponsiveContainer,
-    Cell,
-} from 'recharts';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { useAtomValue } from 'jotai';
 import { hackathonAtom } from '@/app/(auth)/ClientContext';
+import { Button } from '@/components/ui/button';
 import {
-    DEMOGRAPHIC_CHART_DESCRIPTIONS,
-    DEMOGRAPHIC_CHART_LABELS,
-    DEMOGRAPHIC_STAT_ROLES,
-    type DemographicStatRole,
-} from '@/lib/statistics/demographicRoles';
-
-type PieSlice = { name: string; value: number; fill: string };
-type Cohort = 'all' | 'accepted';
-type ChartsByRole = Partial<Record<DemographicStatRole, PieSlice[]>>;
-
-type StatsPayload = {
-    datasets?: {
-        all?: ChartsByRole;
-        accepted?: ChartsByRole;
-    };
-    // legacy shape before this change
-    pronouns?: PieSlice[];
-    experience?: PieSlice[];
-    school?: PieSlice[];
-    levelStudy?: PieSlice[];
-};
-
-function useResponsiveChartSize() {
-    const [chartSize, setChartSize] = useState({
-        outerRadius: 80,
-        innerRadius: 50,
-        fontSize: 12,
-        legendLayout: 'vertical' as 'vertical' | 'horizontal',
-    });
-
-    useEffect(() => {
-        const updateSize = () => {
-            const width = window.innerWidth;
-            if (width < 640) {
-                setChartSize({
-                    outerRadius: 50,
-                    innerRadius: 30,
-                    fontSize: 10,
-                    legendLayout: 'horizontal',
-                });
-            } else if (width < 768) {
-                setChartSize({
-                    outerRadius: 60,
-                    innerRadius: 35,
-                    fontSize: 11,
-                    legendLayout: 'horizontal',
-                });
-            } else if (width < 1024) {
-                setChartSize({
-                    outerRadius: 70,
-                    innerRadius: 45,
-                    fontSize: 12,
-                    legendLayout: 'vertical',
-                });
-            } else {
-                setChartSize({
-                    outerRadius: 80,
-                    innerRadius: 50,
-                    fontSize: 12,
-                    legendLayout: 'vertical',
-                });
-            }
-        };
-
-        updateSize();
-        window.addEventListener('resize', updateSize);
-        return () => window.removeEventListener('resize', updateSize);
-    }, []);
-
-    return chartSize;
-}
-
-function CustomLegend({
-    payload,
-    onMouseEnter,
-    onMouseLeave,
-    activeIndex,
-}: any) {
-    return (
-        <div className="flex w-full flex-wrap justify-center gap-1">
-            {payload.map((entry: any, index: number) => (
-                <div
-                    key={index}
-                    className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-0.5 transition-all duration-200 ${
-                        activeIndex === index
-                            ? 'scale-105 bg-white/10'
-                            : 'hover:bg-white/5'
-                    }`}
-                    onMouseEnter={() => onMouseEnter(index)}
-                    onMouseLeave={onMouseLeave}
-                >
-                    <div
-                        className="h-3 w-3 rounded-full"
-                        style={{ backgroundColor: entry.color }}
-                    />
-                    <span className="text-xs text-white/60">{entry.value}</span>
-                </div>
-            ))}
-        </div>
-    );
-}
-
-function StatisticsCard({
-    title,
-    description,
-    data,
-    activeIndex,
-    setActiveIndex,
-    chartSize,
-}: {
-    title: string;
-    description: string;
-    data: PieSlice[];
-    activeIndex: number | null;
-    setActiveIndex: (index: number | null) => void;
-    chartSize: ReturnType<typeof useResponsiveChartSize>;
-}) {
-    return (
-        <Card>
-            <CardHeader>
-                <CardTitle>{title}</CardTitle>
-                <CardDescription className="text-right md:text-left">
-                    {description}
-                </CardDescription>
-            </CardHeader>
-            <CardContent>
-                <div className="h-[350px] w-full">
-                    {data.length === 0 ? (
-                        <p className="text-sm text-white/50">
-                            No data for this field (question may be missing
-                            displayRole on this hackathon form).
-                        </p>
-                    ) : (
-                        <ResponsiveContainer width="100%" height="100%">
-                            <RechartsPieChart>
-                                <RechartsPie
-                                    data={data}
-                                    dataKey="value"
-                                    nameKey="name"
-                                    cx="50%"
-                                    cy="50%"
-                                    outerRadius={chartSize.outerRadius}
-                                    innerRadius={chartSize.innerRadius}
-                                    stroke="none"
-                                    onMouseEnter={(_data: any, index: number) =>
-                                        setActiveIndex(index)
-                                    }
-                                    onMouseLeave={() => setActiveIndex(null)}
-                                >
-                                    {data.map((entry, index) => (
-                                        <Cell
-                                            key={`cell-${index}`}
-                                            fill={entry.fill}
-                                            opacity={
-                                                activeIndex === null ||
-                                                activeIndex === index
-                                                    ? 1
-                                                    : 0.3
-                                            }
-                                        />
-                                    ))}
-                                </RechartsPie>
-                                <RechartsTooltip
-                                    contentStyle={{
-                                        backgroundColor: '#0f0f0f',
-                                        border: '1px solid #525252',
-                                        borderRadius: '8px',
-                                        fontSize: chartSize.fontSize,
-                                        color: '#f5f5f5',
-                                        boxShadow:
-                                            '0 4px 6px -1px rgba(0, 0, 0, 0.3)',
-                                    }}
-                                    labelStyle={{ color: '#f5f5f5' }}
-                                    itemStyle={{ color: '#f5f5f5' }}
-                                />
-                                <Legend
-                                    content={(props) => (
-                                        <CustomLegend
-                                            {...props}
-                                            onMouseEnter={(index: number) =>
-                                                setActiveIndex(index)
-                                            }
-                                            onMouseLeave={() =>
-                                                setActiveIndex(null)
-                                            }
-                                            activeIndex={activeIndex}
-                                        />
-                                    )}
-                                />
-                            </RechartsPieChart>
-                        </ResponsiveContainer>
-                    )}
-                </div>
-            </CardContent>
-        </Card>
-    );
-}
-
-function resolveChartsForCohort(
-    payload: StatsPayload | null,
-    cohort: Cohort
-): ChartsByRole {
-    if (!payload) return {};
-
-    if (payload.datasets?.[cohort]) {
-        return payload.datasets[cohort] ?? {};
-    }
-
-    // Legacy blob (pre-rewrite): treat as accepted-only with old keys
-    if (cohort === 'accepted') {
-        return {
-            pronouns: payload.pronouns ?? [],
-            priorHackathons: payload.experience ?? [],
-            school: payload.school ?? [],
-            education: payload.levelStudy ?? [],
-        };
-    }
-
-    return {};
-}
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    StatisticsChartsGrid,
+    StatisticsChartsSkeleton,
+    useResponsiveChartSize,
+} from '@/components/statistics/StatisticsCharts';
+import { trpc } from '@/trpc/client';
+import {
+    resolveChartsForCohort,
+    type Cohort,
+    type StatsPayload,
+} from '@/lib/statistics/statsTypes';
 
 export default function StatisticsPage() {
     const hackathon = useAtomValue(hackathonAtom);
     const chartSize = useResponsiveChartSize();
+    const hasSetInitialHackathon = useRef(false);
+
+    const { data: hackathons = [] } = trpc.hackathons.getHackathons.useQuery();
+    const [selectedHackathonId, setSelectedHackathonId] = useState<
+        number | null
+    >(null);
 
     const [payload, setPayload] = useState<StatsPayload | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [cohort, setCohort] = useState<Cohort>('accepted');
-    const [activeIndexes, setActiveIndexes] = useState<
-        Partial<Record<DemographicStatRole, number | null>>
-    >({});
 
     useEffect(() => {
+        if (hasSetInitialHackathon.current) return;
+        if (hackathon?.id) {
+            hasSetInitialHackathon.current = true;
+            setSelectedHackathonId(hackathon.id);
+        }
+    }, [hackathon]);
+
+    useEffect(() => {
+        if (selectedHackathonId == null) return;
+
         const fetchData = async () => {
             try {
                 setLoading(true);
                 const response = await fetch(
-                    `/api/blob/statistics/${hackathon.id}`
+                    `/api/blob/statistics/${selectedHackathonId}`
                 );
                 const result = await response.json();
 
@@ -278,108 +74,109 @@ export default function StatisticsPage() {
         };
 
         fetchData();
-    }, [hackathon.id]);
+    }, [selectedHackathonId]);
 
     const activeCharts = resolveChartsForCohort(payload, cohort);
+    const selectedHackathonName =
+        hackathons.find((h) => h.id === selectedHackathonId)?.name ??
+        'Select hackathon';
 
-    if (loading) {
+    const header = (
+        <div className="flex flex-col gap-3 text-white sm:flex-row sm:items-end sm:justify-between">
+            <div>
+                <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
+                    Application Statistics
+                </h1>
+                <p className="text-sm text-white/60 sm:text-base">
+                    {error
+                        ? 'Error loading statistics data'
+                        : 'Data visualization of hackers'}
+                </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <Link href="/statistics/range">
+                    <Button
+                        type="button"
+                        variant="default"
+                        hierarchy="secondary"
+                        size="compact"
+                    >
+                        Range view
+                    </Button>
+                </Link>
+                {hackathons.length > 0 && (
+                    <Select
+                        value={
+                            selectedHackathonId != null
+                                ? String(selectedHackathonId)
+                                : undefined
+                        }
+                        onValueChange={(value) =>
+                            setSelectedHackathonId(Number(value))
+                        }
+                    >
+                        <SelectTrigger className="w-[200px]">
+                            <SelectValue placeholder="Select hackathon">
+                                {selectedHackathonName}
+                            </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                            {hackathons.map((h) => (
+                                <SelectItem key={h.id} value={String(h.id)}>
+                                    {h.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                )}
+                <button
+                    type="button"
+                    onClick={() => setCohort('all')}
+                    className={`rounded-md px-3 py-1.5 text-sm ${
+                        cohort === 'all'
+                            ? 'bg-white text-black'
+                            : 'bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                >
+                    All applicants
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setCohort('accepted')}
+                    className={`rounded-md px-3 py-1.5 text-sm ${
+                        cohort === 'accepted'
+                            ? 'bg-white text-black'
+                            : 'bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                >
+                    Accepted only
+                </button>
+            </div>
+        </div>
+    );
+
+    if (loading || selectedHackathonId == null) {
         return (
-            <div className="flex h-full w-full flex-col gap-4 sm:gap-6">
-                <div className="text-left text-white">
-                    <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
-                        Application Statistics
-                    </h1>
-                    <p className="text-sm text-white/60 sm:text-base">
-                        Data visualization of hackers
-                    </p>
-                </div>
-                <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
-                    {[...Array(4)].map((_, index) => (
-                        <Card key={index}>
-                            <CardHeader>
-                                <Skeleton className="mb-2 h-6 w-48" />
-                            </CardHeader>
-                            <CardContent>
-                                <Skeleton className="h-[250px] w-full sm:h-[300px]" />
-                            </CardContent>
-                        </Card>
-                    ))}
-                </div>
+            <div className="mx-auto flex h-full w-full flex-col gap-4 sm:gap-6">
+                {header}
+                <StatisticsChartsSkeleton />
             </div>
         );
     }
 
     if (error) {
         return (
-            <div className="flex h-full w-full flex-col gap-4 sm:gap-6">
-                <div className="text-left text-white">
-                    <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
-                        Application Statistics
-                    </h1>
-                    <p className="text-sm text-white/60 sm:text-base">
-                        Error loading statistics data
-                    </p>
-                </div>
+            <div className="mx-auto flex h-full w-full flex-col gap-4 sm:gap-6">
+                {header}
             </div>
         );
     }
 
     return (
         <div className="mx-auto flex h-full w-full flex-col gap-4 sm:gap-6">
-            <div className="flex flex-col gap-3 text-white sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                    <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
-                        Application Statistics
-                    </h1>
-                    <p className="text-sm text-white/60 sm:text-base">
-                        Data visualization of hackers
-                    </p>
-                </div>
-
-                <div className="flex gap-2">
-                    <button
-                        type="button"
-                        onClick={() => setCohort('all')}
-                        className={`rounded-md px-3 py-1.5 text-sm ${
-                            cohort === 'all'
-                                ? 'bg-white text-black'
-                                : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                    >
-                        All applicants
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => setCohort('accepted')}
-                        className={`rounded-md px-3 py-1.5 text-sm ${
-                            cohort === 'accepted'
-                                ? 'bg-white text-black'
-                                : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                    >
-                        Accepted only
-                    </button>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
-                {DEMOGRAPHIC_STAT_ROLES.map((role) => (
-                    <StatisticsCard
-                        key={role}
-                        title={DEMOGRAPHIC_CHART_LABELS[role]}
-                        description={DEMOGRAPHIC_CHART_DESCRIPTIONS[role]}
-                        data={activeCharts[role] ?? []}
-                        activeIndex={activeIndexes[role] ?? null}
-                        setActiveIndex={(index) =>
-                            setActiveIndexes((prev) => ({
-                                ...prev,
-                                [role]: index,
-                            }))
-                        }
-                        chartSize={chartSize}
-                    />
-                ))}
-            </div>
+            {header}
+            <StatisticsChartsGrid charts={activeCharts} chartSize={chartSize} />
         </div>
     );
 }

--- a/src/app/(auth)/(sponsor)/statistics/page.tsx
+++ b/src/app/(auth)/(sponsor)/statistics/page.tsx
@@ -19,8 +19,29 @@ import {
 import { useState, useEffect } from 'react';
 import { useAtomValue } from 'jotai';
 import { hackathonAtom } from '@/app/(auth)/ClientContext';
+import {
+    DEMOGRAPHIC_CHART_DESCRIPTIONS,
+    DEMOGRAPHIC_CHART_LABELS,
+    DEMOGRAPHIC_STAT_ROLES,
+    type DemographicStatRole,
+} from '@/lib/statistics/demographicRoles';
 
-// responsive chart sizing
+type PieSlice = { name: string; value: number; fill: string };
+type Cohort = 'all' | 'accepted';
+type ChartsByRole = Partial<Record<DemographicStatRole, PieSlice[]>>;
+
+type StatsPayload = {
+    datasets?: {
+        all?: ChartsByRole;
+        accepted?: ChartsByRole;
+    };
+    // legacy shape before this change
+    pronouns?: PieSlice[];
+    experience?: PieSlice[];
+    school?: PieSlice[];
+    levelStudy?: PieSlice[];
+};
+
 function useResponsiveChartSize() {
     const [chartSize, setChartSize] = useState({
         outerRadius: 80,
@@ -33,23 +54,20 @@ function useResponsiveChartSize() {
         const updateSize = () => {
             const width = window.innerWidth;
             if (width < 640) {
-                // sm
                 setChartSize({
                     outerRadius: 50,
                     innerRadius: 30,
                     fontSize: 10,
-                    legendLayout: 'horizontal' as 'vertical' | 'horizontal',
+                    legendLayout: 'horizontal',
                 });
             } else if (width < 768) {
-                // md
                 setChartSize({
                     outerRadius: 60,
                     innerRadius: 35,
                     fontSize: 11,
-                    legendLayout: 'horizontal' as 'vertical' | 'horizontal',
+                    legendLayout: 'horizontal',
                 });
             } else if (width < 1024) {
-                // lg
                 setChartSize({
                     outerRadius: 70,
                     innerRadius: 45,
@@ -74,7 +92,6 @@ function useResponsiveChartSize() {
     return chartSize;
 }
 
-// custom legend component with hover interactions
 function CustomLegend({
     payload,
     onMouseEnter,
@@ -115,10 +132,10 @@ function StatisticsCard({
 }: {
     title: string;
     description: string;
-    data: any[];
+    data: PieSlice[];
     activeIndex: number | null;
     setActiveIndex: (index: number | null) => void;
-    chartSize: any;
+    chartSize: ReturnType<typeof useResponsiveChartSize>;
 }) {
     return (
         <Card>
@@ -130,90 +147,111 @@ function StatisticsCard({
             </CardHeader>
             <CardContent>
                 <div className="h-[350px] w-full">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <RechartsPieChart>
-                            <RechartsPie
-                                data={data}
-                                dataKey="value"
-                                nameKey="name"
-                                cx="50%"
-                                cy="50%"
-                                outerRadius={chartSize.outerRadius}
-                                innerRadius={chartSize.innerRadius}
-                                stroke="none"
-                                onMouseEnter={(data: any, index: number) =>
-                                    setActiveIndex(index)
-                                }
-                                onMouseLeave={() => setActiveIndex(null)}
-                            >
-                                {data.map((entry: any, index: number) => (
-                                    <Cell
-                                        key={`cell-${index}`}
-                                        fill={entry.fill}
-                                        opacity={
-                                            activeIndex === null ||
-                                            activeIndex === index
-                                                ? 1
-                                                : 0.3
-                                        }
-                                    />
-                                ))}
-                            </RechartsPie>
-                            <RechartsTooltip
-                                contentStyle={{
-                                    backgroundColor: '#0f0f0f',
-                                    border: '1px solid #525252',
-                                    borderRadius: '8px',
-                                    fontSize: chartSize.fontSize,
-                                    color: '#f5f5f5 !important',
-                                    boxShadow:
-                                        '0 4px 6px -1px rgba(0, 0, 0, 0.3)',
-                                }}
-                                labelStyle={{ color: '#f5f5f5' }}
-                                itemStyle={{ color: '#f5f5f5' }}
-                            />
-                            <Legend
-                                content={(props) => (
-                                    <CustomLegend
-                                        {...props}
-                                        onMouseEnter={(index: number) =>
-                                            setActiveIndex(index)
-                                        }
-                                        onMouseLeave={() =>
-                                            setActiveIndex(null)
-                                        }
-                                        activeIndex={activeIndex}
-                                    />
-                                )}
-                            />
-                        </RechartsPieChart>
-                    </ResponsiveContainer>
+                    {data.length === 0 ? (
+                        <p className="text-sm text-white/50">
+                            No data for this field (question may be missing
+                            displayRole on this hackathon form).
+                        </p>
+                    ) : (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <RechartsPieChart>
+                                <RechartsPie
+                                    data={data}
+                                    dataKey="value"
+                                    nameKey="name"
+                                    cx="50%"
+                                    cy="50%"
+                                    outerRadius={chartSize.outerRadius}
+                                    innerRadius={chartSize.innerRadius}
+                                    stroke="none"
+                                    onMouseEnter={(_data: any, index: number) =>
+                                        setActiveIndex(index)
+                                    }
+                                    onMouseLeave={() => setActiveIndex(null)}
+                                >
+                                    {data.map((entry, index) => (
+                                        <Cell
+                                            key={`cell-${index}`}
+                                            fill={entry.fill}
+                                            opacity={
+                                                activeIndex === null ||
+                                                activeIndex === index
+                                                    ? 1
+                                                    : 0.3
+                                            }
+                                        />
+                                    ))}
+                                </RechartsPie>
+                                <RechartsTooltip
+                                    contentStyle={{
+                                        backgroundColor: '#0f0f0f',
+                                        border: '1px solid #525252',
+                                        borderRadius: '8px',
+                                        fontSize: chartSize.fontSize,
+                                        color: '#f5f5f5',
+                                        boxShadow:
+                                            '0 4px 6px -1px rgba(0, 0, 0, 0.3)',
+                                    }}
+                                    labelStyle={{ color: '#f5f5f5' }}
+                                    itemStyle={{ color: '#f5f5f5' }}
+                                />
+                                <Legend
+                                    content={(props) => (
+                                        <CustomLegend
+                                            {...props}
+                                            onMouseEnter={(index: number) =>
+                                                setActiveIndex(index)
+                                            }
+                                            onMouseLeave={() =>
+                                                setActiveIndex(null)
+                                            }
+                                            activeIndex={activeIndex}
+                                        />
+                                    )}
+                                />
+                            </RechartsPieChart>
+                        </ResponsiveContainer>
+                    )}
                 </div>
             </CardContent>
         </Card>
     );
 }
 
+function resolveChartsForCohort(
+    payload: StatsPayload | null,
+    cohort: Cohort
+): ChartsByRole {
+    if (!payload) return {};
+
+    if (payload.datasets?.[cohort]) {
+        return payload.datasets[cohort] ?? {};
+    }
+
+    // Legacy blob (pre-rewrite): treat as accepted-only with old keys
+    if (cohort === 'accepted') {
+        return {
+            pronouns: payload.pronouns ?? [],
+            priorHackathons: payload.experience ?? [],
+            school: payload.school ?? [],
+            education: payload.levelStudy ?? [],
+        };
+    }
+
+    return {};
+}
+
 export default function StatisticsPage() {
     const hackathon = useAtomValue(hackathonAtom);
     const chartSize = useResponsiveChartSize();
 
-    const [pieChartData, setPieChartData] = useState<any>(null);
+    const [payload, setPayload] = useState<StatsPayload | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-
-    const [activePronounsIndex, setActivePronounsIndex] = useState<
-        number | null
-    >(null);
-    const [activeExperienceIndex, setActiveExperienceIndex] = useState<
-        number | null
-    >(null);
-    const [activeLevelStudyIndex, setActiveLevelStudyIndex] = useState<
-        number | null
-    >(null);
-    const [activeSchoolIndex, setActiveSchoolIndex] = useState<number | null>(
-        null
-    );
+    const [cohort, setCohort] = useState<Cohort>('accepted');
+    const [activeIndexes, setActiveIndexes] = useState<
+        Partial<Record<DemographicStatRole, number | null>>
+    >({});
 
     useEffect(() => {
         const fetchData = async () => {
@@ -225,15 +263,15 @@ export default function StatisticsPage() {
                 const result = await response.json();
 
                 if (result.success) {
-                    setPieChartData(result.data);
+                    setPayload(result.data);
                     setError(null);
                 } else {
                     setError(result.error || 'Failed to fetch statistics data');
-                    setPieChartData(null);
+                    setPayload(null);
                 }
-            } catch (err) {
+            } catch {
                 setError('Failed to fetch statistics data');
-                setPieChartData(null);
+                setPayload(null);
             } finally {
                 setLoading(false);
             }
@@ -242,10 +280,7 @@ export default function StatisticsPage() {
         fetchData();
     }, [hackathon.id]);
 
-    const pronounsData = pieChartData?.pronouns || [];
-    const experienceData = pieChartData?.experience || [];
-    const levelStudyData = pieChartData?.levelStudy || [];
-    const schoolData = pieChartData?.school || [];
+    const activeCharts = resolveChartsForCohort(payload, cohort);
 
     if (loading) {
         return (
@@ -258,7 +293,6 @@ export default function StatisticsPage() {
                         Data visualization of hackers
                     </p>
                 </div>
-
                 <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
                     {[...Array(4)].map((_, index) => (
                         <Card key={index}>
@@ -267,7 +301,6 @@ export default function StatisticsPage() {
                             </CardHeader>
                             <CardContent>
                                 <Skeleton className="h-[250px] w-full sm:h-[300px]" />
-                                <Skeleton className="h-4 w-full" />
                             </CardContent>
                         </Card>
                     ))}
@@ -293,51 +326,59 @@ export default function StatisticsPage() {
 
     return (
         <div className="mx-auto flex h-full w-full flex-col gap-4 sm:gap-6">
-            <div className="text-white">
-                <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
-                    Application Statistics
-                </h1>
-                <p className="text-sm text-white/60 sm:text-base">
-                    Data visualization of hackers
-                </p>
+            <div className="flex flex-col gap-3 text-white sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
+                        Application Statistics
+                    </h1>
+                    <p className="text-sm text-white/60 sm:text-base">
+                        Data visualization of hackers
+                    </p>
+                </div>
+
+                <div className="flex gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setCohort('all')}
+                        className={`rounded-md px-3 py-1.5 text-sm ${
+                            cohort === 'all'
+                                ? 'bg-white text-black'
+                                : 'bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                    >
+                        All applicants
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setCohort('accepted')}
+                        className={`rounded-md px-3 py-1.5 text-sm ${
+                            cohort === 'accepted'
+                                ? 'bg-white text-black'
+                                : 'bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                    >
+                        Accepted only
+                    </button>
+                </div>
             </div>
 
             <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
-                <StatisticsCard
-                    title="Pronouns Distribution"
-                    description="Applicant pronouns"
-                    data={pronounsData}
-                    activeIndex={activePronounsIndex}
-                    setActiveIndex={setActivePronounsIndex}
-                    chartSize={chartSize}
-                />
-
-                <StatisticsCard
-                    title="Hackathon Experience"
-                    description="Previous hackathon participation"
-                    data={experienceData}
-                    activeIndex={activeExperienceIndex}
-                    setActiveIndex={setActiveExperienceIndex}
-                    chartSize={chartSize}
-                />
-
-                <StatisticsCard
-                    title="Level of Study"
-                    description="Distribution of academic levels"
-                    data={levelStudyData}
-                    activeIndex={activeLevelStudyIndex}
-                    setActiveIndex={setActiveLevelStudyIndex}
-                    chartSize={chartSize}
-                />
-
-                <StatisticsCard
-                    title="School Demographics"
-                    description="Participant distribution by institution"
-                    data={schoolData}
-                    activeIndex={activeSchoolIndex}
-                    setActiveIndex={setActiveSchoolIndex}
-                    chartSize={chartSize}
-                />
+                {DEMOGRAPHIC_STAT_ROLES.map((role) => (
+                    <StatisticsCard
+                        key={role}
+                        title={DEMOGRAPHIC_CHART_LABELS[role]}
+                        description={DEMOGRAPHIC_CHART_DESCRIPTIONS[role]}
+                        data={activeCharts[role] ?? []}
+                        activeIndex={activeIndexes[role] ?? null}
+                        setActiveIndex={(index) =>
+                            setActiveIndexes((prev) => ({
+                                ...prev,
+                                [role]: index,
+                            }))
+                        }
+                        chartSize={chartSize}
+                    />
+                ))}
             </div>
         </div>
     );

--- a/src/app/(auth)/(sponsor)/statistics/range/page.tsx
+++ b/src/app/(auth)/(sponsor)/statistics/range/page.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useAtomValue } from 'jotai';
+import { hackathonAtom } from '@/app/(auth)/ClientContext';
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    StatisticsChartsGrid,
+    StatisticsChartsSkeleton,
+    useResponsiveChartSize,
+} from '@/components/statistics/StatisticsCharts';
+import { trpc } from '@/trpc/client';
+import {
+    mergeStatsPayloads,
+    type Cohort,
+    type StatsPayload,
+} from '@/lib/statistics/statsTypes';
+
+type HackathonOption = {
+    id: number;
+    name: string;
+    startDate: string;
+};
+
+function sortHackathons(hackathons: HackathonOption[]) {
+    return [...hackathons].sort((a, b) => {
+        const aTime = Date.parse(a.startDate);
+        const bTime = Date.parse(b.startDate);
+        if (
+            Number.isFinite(aTime) &&
+            Number.isFinite(bTime) &&
+            aTime !== bTime
+        ) {
+            return aTime - bTime;
+        }
+        return a.id - b.id;
+    });
+}
+
+export default function StatisticsRangePage() {
+    const activeHackathon = useAtomValue(hackathonAtom);
+    const chartSize = useResponsiveChartSize();
+    const { data: hackathons = [] } = trpc.hackathons.getHackathons.useQuery();
+
+    const sortedHackathons = useMemo(
+        () => sortHackathons(hackathons as HackathonOption[]),
+        [hackathons]
+    );
+
+    const [fromId, setFromId] = useState<number | null>(null);
+    const [toId, setToId] = useState<number | null>(null);
+    const [cohort, setCohort] = useState<Cohort>('accepted');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [payloads, setPayloads] = useState<StatsPayload[]>([]);
+    const [missingNames, setMissingNames] = useState<string[]>([]);
+    const [includedNames, setIncludedNames] = useState<string[]>([]);
+
+    useEffect(() => {
+        if (sortedHackathons.length === 0) return;
+        if (fromId != null && toId != null) return;
+
+        const fallbackId =
+            activeHackathon?.id ??
+            sortedHackathons[sortedHackathons.length - 1]?.id ??
+            null;
+        if (fallbackId == null) return;
+
+        setFromId((prev) => prev ?? fallbackId);
+        setToId((prev) => prev ?? fallbackId);
+    }, [sortedHackathons, activeHackathon, fromId, toId]);
+
+    const rangeHackathons = useMemo(() => {
+        if (fromId == null || toId == null) return [];
+
+        const fromIndex = sortedHackathons.findIndex((h) => h.id === fromId);
+        const toIndex = sortedHackathons.findIndex((h) => h.id === toId);
+        if (fromIndex < 0 || toIndex < 0) return [];
+
+        const start = Math.min(fromIndex, toIndex);
+        const end = Math.max(fromIndex, toIndex);
+        return sortedHackathons.slice(start, end + 1);
+    }, [sortedHackathons, fromId, toId]);
+
+    useEffect(() => {
+        if (rangeHackathons.length === 0) return;
+
+        let cancelled = false;
+
+        const fetchRange = async () => {
+            setLoading(true);
+            setError(null);
+
+            try {
+                const results = await Promise.all(
+                    rangeHackathons.map(async (h) => {
+                        const response = await fetch(
+                            `/api/blob/statistics/${h.id}`
+                        );
+                        const result = await response.json();
+                        return {
+                            hackathon: h,
+                            success: Boolean(result.success),
+                            data: (result.data ?? null) as StatsPayload | null,
+                        };
+                    })
+                );
+
+                if (cancelled) return;
+
+                const found = results.filter((r) => r.success && r.data);
+                const missing = results
+                    .filter((r) => !r.success || !r.data)
+                    .map((r) => r.hackathon.name);
+
+                setPayloads(found.map((r) => r.data!));
+                setIncludedNames(found.map((r) => r.hackathon.name));
+                setMissingNames(missing);
+
+                if (found.length === 0) {
+                    setError(
+                        'No statistics found for hackathons in this range. Generate stats for each hackathon first.'
+                    );
+                }
+            } catch {
+                if (!cancelled) {
+                    setError('Failed to load statistics for this range');
+                    setPayloads([]);
+                    setIncludedNames([]);
+                    setMissingNames([]);
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        fetchRange();
+        return () => {
+            cancelled = true;
+        };
+    }, [rangeHackathons]);
+
+    const charts = useMemo(
+        () => mergeStatsPayloads(payloads, cohort),
+        [payloads, cohort]
+    );
+
+    const fromName =
+        sortedHackathons.find((h) => h.id === fromId)?.name ?? 'From';
+    const toName = sortedHackathons.find((h) => h.id === toId)?.name ?? 'To';
+
+    const header = (
+        <div className="flex flex-col gap-3 text-white sm:flex-row sm:items-end sm:justify-between">
+            <div>
+                <h1 className="mb-2 text-2xl font-bold text-white sm:text-3xl">
+                    Statistics Range
+                </h1>
+                <p className="text-sm text-white/60 sm:text-base">
+                    Combined demographics across a contiguous hackathon range
+                </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <Link href="/statistics">
+                    <Button
+                        type="button"
+                        variant="default"
+                        hierarchy="secondary"
+                        size="compact"
+                    >
+                        Single hackathon
+                    </Button>
+                </Link>
+                {sortedHackathons.length > 0 && (
+                    <>
+                        <Select
+                            value={fromId != null ? String(fromId) : undefined}
+                            onValueChange={(value) => setFromId(Number(value))}
+                        >
+                            <SelectTrigger className="w-[180px]">
+                                <SelectValue placeholder="From">
+                                    {fromName}
+                                </SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                                {sortedHackathons.map((h) => (
+                                    <SelectItem key={h.id} value={String(h.id)}>
+                                        {h.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <span className="text-sm text-white/50">to</span>
+                        <Select
+                            value={toId != null ? String(toId) : undefined}
+                            onValueChange={(value) => setToId(Number(value))}
+                        >
+                            <SelectTrigger className="w-[180px]">
+                                <SelectValue placeholder="To">
+                                    {toName}
+                                </SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                                {sortedHackathons.map((h) => (
+                                    <SelectItem key={h.id} value={String(h.id)}>
+                                        {h.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </>
+                )}
+                <button
+                    type="button"
+                    onClick={() => setCohort('all')}
+                    className={`rounded-md px-3 py-1.5 text-sm ${
+                        cohort === 'all'
+                            ? 'bg-white text-black'
+                            : 'bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                >
+                    All applicants
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setCohort('accepted')}
+                    className={`rounded-md px-3 py-1.5 text-sm ${
+                        cohort === 'accepted'
+                            ? 'bg-white text-black'
+                            : 'bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                >
+                    Accepted only
+                </button>
+            </div>
+        </div>
+    );
+
+    return (
+        <div className="mx-auto flex h-full w-full flex-col gap-4 sm:gap-6">
+            {header}
+
+            {(includedNames.length > 0 || missingNames.length > 0) && (
+                <div className="text-sm text-white/50">
+                    {includedNames.length > 0 && (
+                        <p>
+                            Including: {includedNames.join(', ')} (
+                            {includedNames.length})
+                        </p>
+                    )}
+                    {missingNames.length > 0 && (
+                        <p className="text-white/40">
+                            Missing stats blob: {missingNames.join(', ')}
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {loading || fromId == null || toId == null ? (
+                <StatisticsChartsSkeleton />
+            ) : error ? (
+                <p className="text-sm text-white/50">{error}</p>
+            ) : (
+                <StatisticsChartsGrid
+                    charts={charts}
+                    chartSize={chartSize}
+                    emptyMessage="No data in this range for this field."
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/(auth)/admin/review/components/applications-table/ReviewApplicantsTable.tsx
+++ b/src/app/(auth)/admin/review/components/applications-table/ReviewApplicantsTable.tsx
@@ -197,6 +197,7 @@ export function ReviewApplicantsTable({
         useState<Set<number> | null>(null);
     const [filterMenuOpen, setFilterMenuOpen] = useState(false);
     const rowRefs = useRef(new Map<string, HTMLTableRowElement>());
+    const tableScrollContainerRef = useRef<HTMLDivElement | null>(null);
     const [selectionMenuPos, setSelectionMenuPos] = useState<{
         top: number;
         left: number;
@@ -313,6 +314,7 @@ export function ReviewApplicantsTable({
             setRowSelection,
             rowRefs,
             lastSelectionAnchorRef,
+            scrollContainerRef: tableScrollContainerRef,
         });
 
     const selectColWidth = table.getColumn('select')?.getSize() ?? 44;
@@ -521,13 +523,30 @@ export function ReviewApplicantsTable({
             return;
         }
 
-        const firstRect = els[0].getBoundingClientRect();
         const lastRect = els[els.length - 1].getBoundingClientRect();
         const horizontalOffset = 225;
-        setSelectionMenuPos({
-            top: lastRect.bottom + 8,
-            left: firstRect.left + horizontalOffset,
-        });
+        const menuWidth = 420;
+        const menuHeight = 48;
+        const pad = 12;
+
+        const scrollRect =
+            tableScrollContainerRef.current?.getBoundingClientRect();
+        const viewLeft = scrollRect?.left ?? pad;
+        const viewRight = scrollRect?.right ?? window.innerWidth;
+
+        // Stay in the visible table area while scrolling horizontally.
+        const preferredLeft = viewLeft + horizontalOffset;
+        const maxLeft = Math.max(viewLeft + pad, viewRight - menuWidth - pad);
+        const left = Math.min(preferredLeft, maxLeft);
+
+        // Stay under the lowest selected row while scrolling vertically.
+        const preferredTop = lastRect.bottom + 8;
+        const top = Math.min(
+            Math.max(preferredTop, pad),
+            window.innerHeight - menuHeight - pad
+        );
+
+        setSelectionMenuPos({ top, left });
     }, [rowSelection, pagination, tableData, sorting, globalFilter]);
 
     useLayoutEffect(() => {
@@ -537,12 +556,24 @@ export function ReviewApplicantsTable({
     useEffect(() => {
         if (!hasSelection) return;
 
-        const onReposition = () => updateSelectionMenuPosition();
-        window.addEventListener('resize', onReposition);
-        window.addEventListener('scroll', onReposition, true);
+        let scrollEndTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const onScroll = () => {
+            if (scrollEndTimer) clearTimeout(scrollEndTimer);
+            // Keep the bar fixed during scroll; snap to the lowest selected row after.
+            scrollEndTimer = setTimeout(() => {
+                updateSelectionMenuPosition();
+            }, 150);
+        };
+
+        const onResize = () => updateSelectionMenuPosition();
+
+        window.addEventListener('resize', onResize);
+        window.addEventListener('scroll', onScroll, true);
         return () => {
-            window.removeEventListener('resize', onReposition);
-            window.removeEventListener('scroll', onReposition, true);
+            window.removeEventListener('resize', onResize);
+            window.removeEventListener('scroll', onScroll, true);
+            if (scrollEndTimer) clearTimeout(scrollEndTimer);
         };
     }, [hasSelection, updateSelectionMenuPosition]);
 
@@ -638,7 +669,7 @@ export function ReviewApplicantsTable({
                         }
                     />
                 ) : null}
-                <div className="overflow-x-auto">
+                <div ref={tableScrollContainerRef} className="overflow-x-auto">
                     <table
                         className="w-full text-left"
                         style={{ tableLayout: 'fixed', width: '100%' }}

--- a/src/app/(auth)/admin/review/components/applications-table/useMarqueeRowSelection.ts
+++ b/src/app/(auth)/admin/review/components/applications-table/useMarqueeRowSelection.ts
@@ -11,6 +11,9 @@ import {
 import type { RowSelectionState, Table } from '@tanstack/react-table';
 import type { Applicant } from './types';
 
+const AUTO_SCROLL_EDGE_PX = 48;
+const AUTO_SCROLL_MAX_SPEED = 28;
+
 function isRowDragSelectBlocked(target: EventTarget | null): boolean {
     if (!(target instanceof Element)) return false;
     return Boolean(
@@ -18,6 +21,32 @@ function isRowDragSelectBlocked(target: EventTarget | null): boolean {
             'button, a, input, textarea, select, label, [role="menuitem"], [data-radix-popper-content-wrapper], [data-no-row-drag]'
         )
     );
+}
+
+function getVerticalScrollParent(el: HTMLElement | null): HTMLElement | null {
+    let node: HTMLElement | null = el;
+    while (node) {
+        const { overflowY } = getComputedStyle(node);
+        if (
+            (overflowY === 'auto' ||
+                overflowY === 'scroll' ||
+                overflowY === 'overlay') &&
+            node.scrollHeight > node.clientHeight + 1
+        ) {
+            return node;
+        }
+        node = node.parentElement;
+    }
+    const scrolling = document.scrollingElement;
+    return scrolling instanceof HTMLElement
+        ? scrolling
+        : document.documentElement;
+}
+
+function edgeScrollDelta(distanceIntoEdge: number, edgePx: number): number {
+    if (distanceIntoEdge <= 0) return 0;
+    const t = Math.min(1, distanceIntoEdge / edgePx);
+    return Math.ceil(t * t * AUTO_SCROLL_MAX_SPEED);
 }
 
 export type MarqueeBox = {
@@ -37,6 +66,7 @@ type UseMarqueeRowSelectionArgs = {
     ) => void;
     rowRefs: MutableRefObject<Map<string, HTMLTableRowElement>>;
     lastSelectionAnchorRef: MutableRefObject<number | null>;
+    scrollContainerRef: MutableRefObject<HTMLElement | null>;
 };
 
 export function useMarqueeRowSelection({
@@ -45,6 +75,7 @@ export function useMarqueeRowSelection({
     setRowSelection,
     rowRefs,
     lastSelectionAnchorRef,
+    scrollContainerRef,
 }: UseMarqueeRowSelectionArgs) {
     const [marqueeBox, setMarqueeBox] = useState<MarqueeBox | null>(null);
     const marqueeSelectRef = useRef<{
@@ -56,6 +87,7 @@ export function useMarqueeRowSelection({
         baseSelection: RowSelectionState;
         startVisualIndex: number | null;
     } | null>(null);
+    const autoScrollRafRef = useRef<number | null>(null);
 
     const applyRowRangeSelection = useCallback(
         (
@@ -133,6 +165,78 @@ export function useMarqueeRowSelection({
         []
     );
 
+    const stopAutoScroll = useCallback(() => {
+        if (autoScrollRafRef.current != null) {
+            cancelAnimationFrame(autoScrollRafRef.current);
+            autoScrollRafRef.current = null;
+        }
+    }, []);
+
+    const tickAutoScroll = useCallback(() => {
+        const drag = marqueeSelectRef.current;
+        if (!drag) {
+            autoScrollRafRef.current = null;
+            return;
+        }
+
+        const container = scrollContainerRef.current;
+        let deltaX = 0;
+        let deltaY = 0;
+
+        if (container) {
+            const rect = container.getBoundingClientRect();
+            const leftEdge = rect.left + AUTO_SCROLL_EDGE_PX - drag.currentX;
+            const rightEdge =
+                drag.currentX - (rect.right - AUTO_SCROLL_EDGE_PX);
+            const leftDelta = edgeScrollDelta(leftEdge, AUTO_SCROLL_EDGE_PX);
+            const rightDelta = edgeScrollDelta(rightEdge, AUTO_SCROLL_EDGE_PX);
+
+            if (leftDelta > 0 || rightDelta > 0) {
+                const before = container.scrollLeft;
+                container.scrollLeft += rightDelta - leftDelta;
+                deltaX += container.scrollLeft - before;
+            }
+        }
+
+        const verticalParent = getVerticalScrollParent(container);
+        if (verticalParent) {
+            const rect = verticalParent.getBoundingClientRect();
+            const topEdge = rect.top + AUTO_SCROLL_EDGE_PX - drag.currentY;
+            const bottomEdge =
+                drag.currentY - (rect.bottom - AUTO_SCROLL_EDGE_PX);
+            const topDelta = edgeScrollDelta(topEdge, AUTO_SCROLL_EDGE_PX);
+            const bottomDelta = edgeScrollDelta(
+                bottomEdge,
+                AUTO_SCROLL_EDGE_PX
+            );
+
+            if (topDelta > 0 || bottomDelta > 0) {
+                const before = verticalParent.scrollTop;
+                verticalParent.scrollTop += bottomDelta - topDelta;
+                deltaY += verticalParent.scrollTop - before;
+            }
+        }
+
+        if (deltaX !== 0 || deltaY !== 0) {
+            // Keep the marquee origin anchored to content as the viewport scrolls.
+            drag.startX -= deltaX;
+            drag.startY -= deltaY;
+            updateMarqueeBox(
+                drag.startX,
+                drag.startY,
+                drag.currentX,
+                drag.currentY
+            );
+        }
+
+        autoScrollRafRef.current = requestAnimationFrame(tickAutoScroll);
+    }, [scrollContainerRef, updateMarqueeBox]);
+
+    const startAutoScroll = useCallback(() => {
+        if (autoScrollRafRef.current != null) return;
+        autoScrollRafRef.current = requestAnimationFrame(tickAutoScroll);
+    }, [tickAutoScroll]);
+
     const handleRowPointerDown = useCallback(
         (event: ReactPointerEvent<HTMLTableRowElement>, rowIndex: number) => {
             if (event.button !== 0 || isRowDragSelectBlocked(event.target)) {
@@ -170,11 +274,13 @@ export function useMarqueeRowSelection({
                 event.clientX,
                 event.clientY
             );
+            startAutoScroll();
         },
         [
             applyRowRangeSelection,
             lastSelectionAnchorRef,
             rowSelection,
+            startAutoScroll,
             updateMarqueeBox,
         ]
     );
@@ -191,11 +297,14 @@ export function useMarqueeRowSelection({
                 drag.currentX,
                 drag.currentY
             );
+            startAutoScroll();
         };
 
         const onPointerUp = () => {
             const drag = marqueeSelectRef.current;
             if (!drag) return;
+
+            stopAutoScroll();
 
             const left = Math.min(drag.startX, drag.currentX);
             const top = Math.min(drag.startY, drag.currentY);
@@ -238,11 +347,14 @@ export function useMarqueeRowSelection({
             window.removeEventListener('pointermove', onPointerMove);
             window.removeEventListener('pointerup', onPointerUp);
             window.removeEventListener('pointercancel', onPointerUp);
+            stopAutoScroll();
         };
     }, [
         applyRowRangeSelection,
         lastSelectionAnchorRef,
         selectRowsIntersectingRect,
+        startAutoScroll,
+        stopAutoScroll,
         updateMarqueeBox,
     ]);
 

--- a/src/app/(public)/signout/page.tsx
+++ b/src/app/(public)/signout/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { signOutAndRedirect } from '@/auth/auth-client';
+import { signOutAndRedirect, useAuthSession } from '@/auth/auth-client';
 import { useEffect } from 'react';
 import { FullPageInfo } from '@/components/ui/FullPageInfo';
 import { resetPostHogUser } from '@/lib/analytics/posthog';
@@ -8,10 +8,14 @@ import { resetPostHogUser } from '@/lib/analytics/posthog';
 // Force sign-out client side (and delete cookie), e.g. when a live session
 // doesn't refer to a valid user in the db.
 export default function SignOutPage() {
+    const session = useAuthSession();
+
     useEffect(() => {
+        if (session.status === 'loading') return;
+
         resetPostHogUser();
         void signOutAndRedirect('/login');
-    }, []);
+    }, [session.status]);
 
     return (
         <div className="flex h-full min-h-dvh w-full flex-1 flex-col items-center justify-center">

--- a/src/app/api/blob/statistics/fetch/route.ts
+++ b/src/app/api/blob/statistics/fetch/route.ts
@@ -1,64 +1,13 @@
 import { connection, NextRequest, NextResponse } from 'next/server';
 import { databaseClient } from '@/db/client';
 import { applications } from '@/db/schema/applications';
-import { eq, and, or } from 'drizzle-orm';
+import { hackathons } from '@/db/schema/hackathons';
+import { eq } from 'drizzle-orm';
 import { put } from '@vercel/blob';
-
-// helper function to process field data for pie charts
-function processFieldData(applications: any[], fieldKey: string) {
-    const fieldCount = applications.reduce(
-        (acc: Record<string, number>, app: any) => {
-            const value = app.response[fieldKey] || 'Not specified';
-            acc[value] = (acc[value] || 0) + 1;
-            return acc;
-        },
-        {} as Record<string, number>
-    );
-
-    // group categories with less than 6 into "Other"
-    const processedData: Record<string, number> = {};
-    let otherCount = 0;
-
-    Object.entries(fieldCount).forEach(([value, count]) => {
-        if (count >= 5) {
-            processedData[value] = count;
-        } else {
-            otherCount += count;
-        }
-    });
-
-    if (otherCount > 0) {
-        processedData['Other'] = otherCount;
-    }
-
-    // sort by count (descending) and format for pie chart
-    const sortedEntries = Object.entries(processedData).sort(
-        (a, b) => b[1] - a[1]
-    );
-
-    return sortedEntries.map(([value, count], index) => ({
-        name: value,
-        value: count,
-        fill: index === 0 ? '#3730a3' : getColorByIndex(index), // brand-700 for largest
-    }));
-}
-
-// color palette for pie charts
-function getColorByIndex(index: number): string {
-    const colors = [
-        'hsl(220 70% 60%)', // Blue
-        'hsl(160 60% 55%)', // Teal
-        'hsl(45 85% 65%)', // Yellow
-        'hsl(320 70% 65%)', // Pink
-        'hsl(120 50% 55%)', // Green
-        'hsl(280 65% 65%)', // Purple
-        'hsl(15 75% 60%)', // Orange
-        'hsl(0 60% 60%)', // Red
-        'hsl(200 60% 60%)', // Cyan
-        'hsl(60 70% 60%)', // Lime
-    ];
-    return colors[index % colors.length];
-}
+import {
+    buildDemographicPieCharts,
+    type ApplicationForStats,
+} from '@/lib/statistics/buildDemographicStats';
 
 export async function GET(request: NextRequest) {
     await connection();
@@ -67,86 +16,67 @@ export async function GET(request: NextRequest) {
         request.nextUrl.searchParams.get('hackathonId') || '1'
     );
 
+    if (!Number.isFinite(hackathonId)) {
+        return NextResponse.json(
+            { error: 'Invalid hackathonId' },
+            { status: 400 }
+        );
+    }
+
     try {
-        const applications_result = await databaseClient
+        const [hackathon] = await databaseClient
+            .select({
+                id: hackathons.id,
+                applicationQuestions: hackathons.applicationQuestions,
+            })
+            .from(hackathons)
+            .where(eq(hackathons.id, hackathonId));
+
+        if (!hackathon) {
+            return NextResponse.json(
+                { error: `Hackathon ${hackathonId} not found` },
+                { status: 404 }
+            );
+        }
+
+        const applicationsResult = await databaseClient
             .select({
                 userId: applications.userId,
                 response: applications.response,
+                currentStatus: applications.currentStatus,
             })
             .from(applications)
-            .where(
-                and(
-                    eq(applications.hackathonId, hackathonId),
-                    or(
-                        eq(applications.currentStatus, 'Accepted')
-                        // eq(
-                        //     applications.currentStatus,
-                        //     'Accepted - RSVP to Confirm'
-                        // )
-                    )
-                )
-            );
+            .where(eq(applications.hackathonId, hackathonId));
 
-        const filteredApplications = applications_result.map((app) => ({
-            userId: app.userId,
-            response: {
-                '3':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '3' in app.response
-                        ? (app.response as Record<string, any>)['3']
-                        : null,
-                '5':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '5' in app.response
-                        ? (app.response as Record<string, any>)['5']
-                        : null,
-                '16':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '16' in app.response
-                        ? (app.response as Record<string, any>)['16']
-                        : null,
-                '17':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '17' in app.response
-                        ? (app.response as Record<string, any>)['17']
-                        : null,
-                '18':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '18' in app.response
-                        ? (app.response as Record<string, any>)['18']
-                        : null,
-                '19':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '19' in app.response
-                        ? (app.response as Record<string, any>)['19']
-                        : null,
-                '20':
-                    app.response &&
-                    typeof app.response === 'object' &&
-                    '20' in app.response
-                        ? (app.response as Record<string, any>)['20']
-                        : null,
-            },
-        }));
+        const allApps: ApplicationForStats[] = applicationsResult.map(
+            (app) => ({
+                currentStatus: app.currentStatus,
+                response:
+                    app.response && typeof app.response === 'object'
+                        ? (app.response as Record<string, unknown>)
+                        : {},
+            })
+        );
 
-        const pieChartData = {
-            pronouns: processFieldData(filteredApplications, '3'),
-            experience: processFieldData(filteredApplications, '5'),
-            school: processFieldData(filteredApplications, '16'),
-            levelStudy: processFieldData(filteredApplications, '18'),
-            year: processFieldData(filteredApplications, '19'),
-            program: processFieldData(filteredApplications, '20'),
+        const acceptedApps = allApps.filter(
+            (app) => app.currentStatus === 'Accepted'
+        );
+
+        const pages = hackathon.applicationQuestions;
+        const datasets = {
+            all: buildDemographicPieCharts(pages, allApps),
+            accepted: buildDemographicPieCharts(pages, acceptedApps),
+        };
+
+        const payload = {
+            hackathonId,
+            generatedAt: new Date().toISOString(),
+            datasets,
         };
 
         const pieChartBlob = await put(
             `statistics/${hackathonId}/stats.json`,
-            JSON.stringify(pieChartData, null, 2),
+            JSON.stringify(payload, null, 2),
             {
                 access: 'public',
                 contentType: 'application/json',
@@ -157,9 +87,12 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
             success: true,
             message: `Statistics data uploaded to Vercel Blob for hackathon ${hackathonId}`,
-            count: filteredApplications.length,
+            count: {
+                all: allApps.length,
+                accepted: acceptedApps.length,
+            },
             pieChartDataUrl: pieChartBlob.url,
-            pieChartData: pieChartData,
+            data: payload,
         });
     } catch (error) {
         console.error('Error fetching statistics data:', error);

--- a/src/auth/auth-client.ts
+++ b/src/auth/auth-client.ts
@@ -2,14 +2,12 @@ import { createAuthClient } from 'better-auth/react';
 import { magicLinkClient } from 'better-auth/client/plugins';
 import { resolveAuthOrigin } from './authBaseUrl';
 
-// Pass an explicit origin so createAuthClient does not read a bad
+// Pass an explicit origin on the server so createAuthClient does not read a bad
 // BETTER_AUTH_URL from the env (that throws during prerender/build).
-// In the browser, always use the page origin so cookies stay same-site.
+// In the browser, omit baseURL so requests stay same-origin via `/api/auth`
+// (avoids localhost vs 127.0.0.1 vs LAN-IP mismatches that break sign-out).
 export const authClient = createAuthClient({
-    baseURL:
-        typeof window !== 'undefined'
-            ? window.location.origin
-            : resolveAuthOrigin(),
+    ...(typeof window === 'undefined' ? { baseURL: resolveAuthOrigin() } : {}),
     plugins: [magicLinkClient()],
 });
 
@@ -28,8 +26,12 @@ export function useAuthSession() {
 
 /** Clear the Better Auth session and hard-navigate (avoids stale RSC/session UI). */
 export async function signOutAndRedirect(redirectTo = '/login') {
+    // Relative URL so cookies are always sent for the current host in local dev.
     try {
-        await authClient.signOut();
+        await fetch('/api/auth/sign-out', {
+            method: 'POST',
+            credentials: 'include',
+        });
     } catch {
         // Still leave the app even if the API call fails.
     }

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -499,7 +499,7 @@ export default function SideBar({ className, initialData }: NavProps) {
                                                 }
                                             />
                                             <NavLink
-                                                href="#"
+                                                href="/signout"
                                                 label="Sign out"
                                                 icon={
                                                     <ArrowLeftEndOnRectangleIcon className="text-danger-400 h-6 w-6" />
@@ -507,7 +507,8 @@ export default function SideBar({ className, initialData }: NavProps) {
                                                 iconAlt="Sign out logo"
                                                 platform="desktop"
                                                 variant="error"
-                                                onClick={() => {
+                                                onClick={(e) => {
+                                                    e.preventDefault();
                                                     setProfilePopoverOpen(
                                                         false
                                                     );

--- a/src/components/statistics/StatisticsCharts.tsx
+++ b/src/components/statistics/StatisticsCharts.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { ArrowDownTrayIcon } from '@heroicons/react/16/solid';
+import {
+    PieChart as RechartsPieChart,
+    Pie as RechartsPie,
+    Tooltip as RechartsTooltip,
+    ResponsiveContainer,
+    Cell,
+    Sector,
+} from 'recharts';
+import { useCallback, useEffect, useState } from 'react';
+import {
+    DEMOGRAPHIC_CHART_DESCRIPTIONS,
+    DEMOGRAPHIC_CHART_LABELS,
+    DEMOGRAPHIC_STAT_ROLES,
+    type DemographicStatRole,
+} from '@/lib/statistics/demographicRoles';
+import type { PieSlice } from '@/lib/statistics/statsTypes';
+
+function escapeCsvCell(value: string | number): string {
+    const text = String(value);
+    if (/[",\n\r]/.test(text)) {
+        return `"${text.replace(/"/g, '""')}"`;
+    }
+    return text;
+}
+
+export function downloadChartCsv(title: string, data: PieSlice[]) {
+    const total = data.reduce((sum, row) => sum + row.value, 0);
+    const lines = [
+        ['Category', 'Count', 'Percent'].map(escapeCsvCell).join(','),
+        ...data.map((row) => {
+            const pct =
+                total > 0 ? ((row.value / total) * 100).toFixed(1) : '0.0';
+            return [row.name, row.value, pct].map(escapeCsvCell).join(',');
+        }),
+    ];
+
+    const blob = new Blob([lines.join('\n')], {
+        type: 'text/csv;charset=utf-8;',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    const safeName = title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    anchor.href = url;
+    anchor.download = `${safeName || 'chart'}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+}
+
+export function useResponsiveChartSize() {
+    const [chartSize, setChartSize] = useState({
+        outerRadius: 80,
+        innerRadius: 50,
+        fontSize: 12,
+        legendLayout: 'vertical' as 'vertical' | 'horizontal',
+    });
+
+    useEffect(() => {
+        const updateSize = () => {
+            const width = window.innerWidth;
+            if (width < 640) {
+                setChartSize({
+                    outerRadius: 50,
+                    innerRadius: 30,
+                    fontSize: 10,
+                    legendLayout: 'horizontal',
+                });
+            } else if (width < 768) {
+                setChartSize({
+                    outerRadius: 60,
+                    innerRadius: 35,
+                    fontSize: 11,
+                    legendLayout: 'horizontal',
+                });
+            } else if (width < 1024) {
+                setChartSize({
+                    outerRadius: 70,
+                    innerRadius: 45,
+                    fontSize: 12,
+                    legendLayout: 'vertical',
+                });
+            } else {
+                setChartSize({
+                    outerRadius: 80,
+                    innerRadius: 50,
+                    fontSize: 12,
+                    legendLayout: 'vertical',
+                });
+            }
+        };
+
+        updateSize();
+        window.addEventListener('resize', updateSize);
+        return () => window.removeEventListener('resize', updateSize);
+    }, []);
+
+    return chartSize;
+}
+
+function renderActiveShape(props: any) {
+    const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill } =
+        props;
+
+    return (
+        <g>
+            <Sector
+                cx={cx}
+                cy={cy}
+                innerRadius={innerRadius}
+                outerRadius={outerRadius + 8}
+                startAngle={startAngle}
+                endAngle={endAngle}
+                fill={fill}
+                stroke="none"
+            />
+            <Sector
+                cx={cx}
+                cy={cy}
+                innerRadius={outerRadius + 10}
+                outerRadius={outerRadius + 14}
+                startAngle={startAngle}
+                endAngle={endAngle}
+                fill={fill}
+                opacity={0.35}
+                stroke="none"
+            />
+        </g>
+    );
+}
+
+function CustomLegend({
+    data,
+    onMouseEnter,
+    onMouseLeave,
+    activeIndex,
+}: {
+    data: PieSlice[];
+    onMouseEnter: (index: number) => void;
+    onMouseLeave: () => void;
+    activeIndex: number | null;
+}) {
+    const total = data.reduce((sum, entry) => sum + entry.value, 0);
+
+    return (
+        <div
+            className="mt-3 max-h-32 w-full overflow-y-auto overscroll-contain [scrollbar-gutter:stable] [scrollbar-width:thin]"
+            onWheel={(e) => e.stopPropagation()}
+        >
+            <div className="flex flex-col gap-0.5">
+                {data.map((entry, index) => {
+                    const pct =
+                        total > 0 ? Math.round((entry.value / total) * 100) : 0;
+
+                    return (
+                        <div
+                            key={entry.name}
+                            className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition-colors duration-150 ${
+                                activeIndex === index
+                                    ? 'bg-white/10'
+                                    : 'hover:bg-white/5'
+                            }`}
+                            onMouseEnter={() => onMouseEnter(index)}
+                            onMouseLeave={onMouseLeave}
+                        >
+                            <div
+                                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                                style={{ backgroundColor: entry.fill }}
+                            />
+                            <span className="min-w-0 flex-1 truncate text-xs text-white/60">
+                                {entry.name} ({entry.value}, {pct}%)
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function StatisticsCard({
+    title,
+    description,
+    data,
+    activeIndex,
+    setActiveIndex,
+    chartSize,
+    emptyMessage = 'This data was not collected for this hackathon.',
+}: {
+    title: string;
+    description: string;
+    data: PieSlice[];
+    activeIndex: number | null;
+    setActiveIndex: (index: number | null) => void;
+    chartSize: ReturnType<typeof useResponsiveChartSize>;
+    emptyMessage?: string;
+}) {
+    const handleActivate = useCallback(
+        (index: number | null) => {
+            setActiveIndex(index);
+        },
+        [setActiveIndex]
+    );
+
+    return (
+        <Card className="h-full min-h-[420px]">
+            <CardHeader>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <CardTitle>{title}</CardTitle>
+                    <CardDescription className="text-left">
+                        {description}
+                    </CardDescription>
+                </div>
+                {data.length > 0 && (
+                    <Button
+                        type="button"
+                        variant="default"
+                        hierarchy="secondary"
+                        size="compact"
+                        leadingIconChild={
+                            <ArrowDownTrayIcon className="size-4" />
+                        }
+                        onClick={() => downloadChartCsv(title, data)}
+                    >
+                        CSV
+                    </Button>
+                )}
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col">
+                {data.length === 0 ? (
+                    <div className="flex min-h-[300px] flex-1 items-center justify-center px-4">
+                        <p className="text-center text-sm text-white/50">
+                            {emptyMessage}
+                        </p>
+                    </div>
+                ) : (
+                    <div className="flex w-full flex-1 flex-col">
+                        <div className="h-[240px] w-full sm:h-[260px]">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <RechartsPieChart>
+                                    <RechartsPie
+                                        data={data}
+                                        dataKey="value"
+                                        nameKey="name"
+                                        cx="50%"
+                                        cy="50%"
+                                        outerRadius={chartSize.outerRadius}
+                                        innerRadius={chartSize.innerRadius}
+                                        stroke="none"
+                                        activeIndex={
+                                            activeIndex === null
+                                                ? undefined
+                                                : activeIndex
+                                        }
+                                        activeShape={renderActiveShape}
+                                        onMouseEnter={(
+                                            _data: unknown,
+                                            index: number
+                                        ) => handleActivate(index)}
+                                        onMouseLeave={() =>
+                                            handleActivate(null)
+                                        }
+                                    >
+                                        {data.map((entry) => (
+                                            <Cell
+                                                key={`cell-${entry.name}`}
+                                                fill={entry.fill}
+                                            />
+                                        ))}
+                                    </RechartsPie>
+                                    <RechartsTooltip
+                                        contentStyle={{
+                                            backgroundColor: '#0f0f0f',
+                                            border: '1px solid #525252',
+                                            borderRadius: '8px',
+                                            fontSize: chartSize.fontSize,
+                                            color: '#f5f5f5',
+                                            boxShadow:
+                                                '0 4px 6px -1px rgba(0, 0, 0, 0.3)',
+                                        }}
+                                        labelStyle={{ color: '#f5f5f5' }}
+                                        itemStyle={{ color: '#f5f5f5' }}
+                                        animationDuration={150}
+                                    />
+                                </RechartsPieChart>
+                            </ResponsiveContainer>
+                        </div>
+                        <CustomLegend
+                            data={data}
+                            activeIndex={activeIndex}
+                            onMouseEnter={handleActivate}
+                            onMouseLeave={() => handleActivate(null)}
+                        />
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+export function StatisticsChartsGrid({
+    charts,
+    chartSize,
+    emptyMessage,
+}: {
+    charts: Partial<Record<DemographicStatRole, PieSlice[]>>;
+    chartSize: ReturnType<typeof useResponsiveChartSize>;
+    emptyMessage?: string;
+}) {
+    const [activeIndexes, setActiveIndexes] = useState<
+        Partial<Record<DemographicStatRole, number | null>>
+    >({});
+
+    return (
+        <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
+            {DEMOGRAPHIC_STAT_ROLES.map((role) => (
+                <StatisticsCard
+                    key={role}
+                    title={DEMOGRAPHIC_CHART_LABELS[role]}
+                    description={DEMOGRAPHIC_CHART_DESCRIPTIONS[role]}
+                    data={charts[role] ?? []}
+                    activeIndex={activeIndexes[role] ?? null}
+                    setActiveIndex={(index) =>
+                        setActiveIndexes((prev) => {
+                            if ((prev[role] ?? null) === index) {
+                                return prev;
+                            }
+                            return {
+                                ...prev,
+                                [role]: index,
+                            };
+                        })
+                    }
+                    chartSize={chartSize}
+                    emptyMessage={emptyMessage}
+                />
+            ))}
+        </div>
+    );
+}
+
+export function StatisticsChartsSkeleton() {
+    return (
+        <div className="grid grid-cols-1 gap-4 pb-28 sm:gap-6 md:pb-10 xl:grid-cols-2">
+            {[...Array(4)].map((_, index) => (
+                <Card key={index}>
+                    <CardHeader>
+                        <Skeleton className="mb-2 h-6 w-48" />
+                    </CardHeader>
+                    <CardContent>
+                        <Skeleton className="h-[250px] w-full sm:h-[300px]" />
+                    </CardContent>
+                </Card>
+            ))}
+        </div>
+    );
+}

--- a/src/lib/statistics/buildDemographicStats.ts
+++ b/src/lib/statistics/buildDemographicStats.ts
@@ -36,7 +36,9 @@ function getColorByIndex(index: number): string {
     return colors[index % colors.length];
 }
 
-/** Count keys across applicants; rare values (< 5) roll into Other */
+/** Count keys across applicants; singleton answers (count < 2) roll into Other */
+const MIN_COUNT_FOR_OWN_SLICE = 2;
+
 export function processFieldData(allKeys: string[]): PieSlice[] {
     const fieldCount = allKeys.reduce(
         (acc: Record<string, number>, key: string) => {
@@ -50,7 +52,7 @@ export function processFieldData(allKeys: string[]): PieSlice[] {
     let otherCount = 0;
 
     Object.entries(fieldCount).forEach(([value, count]) => {
-        if (count >= 5) {
+        if (count >= MIN_COUNT_FOR_OWN_SLICE) {
             processedData[value] = count;
         } else {
             otherCount += count;

--- a/src/lib/statistics/buildDemographicStats.ts
+++ b/src/lib/statistics/buildDemographicStats.ts
@@ -1,0 +1,109 @@
+import type { InputFormPageData } from '@/components/application_components/types';
+import { resolveApplicationQuestionIdByRole } from '@/lib/applications/applicationReviewExport';
+import { getResponseValue } from '@/lib/admin/submissionExport';
+import {
+    DEMOGRAPHIC_STAT_ROLES,
+    type DemographicStatRole,
+} from './demographicRoles';
+import { answersToCountKeys } from './normalizeFreeText';
+
+export type PieSlice = {
+    name: string;
+    value: number;
+    fill: string;
+};
+
+export type ApplicationForStats = {
+    response: Record<string, unknown>;
+    currentStatus: string;
+};
+
+export type DemographicPieCharts = Record<DemographicStatRole, PieSlice[]>;
+
+function getColorByIndex(index: number): string {
+    const colors = [
+        'hsl(220 70% 60%)',
+        'hsl(160 60% 55%)',
+        'hsl(45 85% 65%)',
+        'hsl(320 70% 65%)',
+        'hsl(120 50% 55%)',
+        'hsl(280 65% 65%)',
+        'hsl(15 75% 60%)',
+        'hsl(0 60% 60%)',
+        'hsl(200 60% 60%)',
+        'hsl(60 70% 60%)',
+    ];
+    return colors[index % colors.length];
+}
+
+/** Count keys across applicants; rare values (< 5) roll into Other */
+export function processFieldData(allKeys: string[]): PieSlice[] {
+    const fieldCount = allKeys.reduce(
+        (acc: Record<string, number>, key: string) => {
+            acc[key] = (acc[key] || 0) + 1;
+            return acc;
+        },
+        {} as Record<string, number>
+    );
+
+    const processedData: Record<string, number> = {};
+    let otherCount = 0;
+
+    Object.entries(fieldCount).forEach(([value, count]) => {
+        if (count >= 5) {
+            processedData[value] = count;
+        } else {
+            otherCount += count;
+        }
+    });
+
+    if (otherCount > 0) {
+        processedData['Other'] = otherCount;
+    }
+
+    const sortedEntries = Object.entries(processedData).sort(
+        (a, b) => b[1] - a[1]
+    );
+
+    return sortedEntries.map(([value, count], index) => ({
+        name: value,
+        value: count,
+        fill: index === 0 ? '#3730a3' : getColorByIndex(index),
+    }));
+}
+
+export function buildRoleToQuestionIdMap(
+    pages: InputFormPageData[] | undefined
+): Partial<Record<DemographicStatRole, string>> {
+    const map: Partial<Record<DemographicStatRole, string>> = {};
+    for (const role of DEMOGRAPHIC_STAT_ROLES) {
+        const id = resolveApplicationQuestionIdByRole(pages, role);
+        if (id) map[role] = id;
+    }
+    return map;
+}
+
+export function buildDemographicPieCharts(
+    pages: InputFormPageData[] | undefined,
+    apps: ApplicationForStats[]
+): DemographicPieCharts {
+    const roleToId = buildRoleToQuestionIdMap(pages);
+    const result = {} as DemographicPieCharts;
+
+    for (const role of DEMOGRAPHIC_STAT_ROLES) {
+        const questionId = roleToId[role];
+        if (!questionId) {
+            result[role] = [];
+            continue;
+        }
+
+        const keys: string[] = [];
+        for (const app of apps) {
+            const raw = getResponseValue(app.response, questionId);
+            keys.push(...answersToCountKeys(raw, role));
+        }
+        result[role] = processFieldData(keys);
+    }
+
+    return result;
+}

--- a/src/lib/statistics/demographicRoles.ts
+++ b/src/lib/statistics/demographicRoles.ts
@@ -1,0 +1,36 @@
+import type { DisplayRole } from '@/components/application_components/types';
+
+export const DEMOGRAPHIC_STAT_ROLES = [
+    'pronouns',
+    'age',
+    'school',
+    'education',
+    'yearOfStudy',
+    'major',
+    'priorHackathons',
+] as const satisfies readonly DisplayRole[];
+
+export type DemographicStatRole = (typeof DEMOGRAPHIC_STAT_ROLES)[number];
+
+export const DEMOGRAPHIC_CHART_LABELS: Record<DemographicStatRole, string> = {
+    pronouns: 'Pronouns',
+    age: 'Age',
+    school: 'School',
+    education: 'Level of Study',
+    yearOfStudy: 'Year of Study',
+    major: 'Major / Program',
+    priorHackathons: 'Hackathon Experience',
+};
+
+export const DEMOGRAPHIC_CHART_DESCRIPTIONS: Record<
+    DemographicStatRole,
+    string
+> = {
+    pronouns: 'Applicant pronouns',
+    age: 'Applicant age distribution',
+    school: 'Participant distribution by institution',
+    education: 'Distribution of academic levels',
+    yearOfStudy: 'Year of study distribution',
+    major: 'Program / major distribution',
+    priorHackathons: 'Previous hackathon participation',
+};

--- a/src/lib/statistics/normalizeFreeText.ts
+++ b/src/lib/statistics/normalizeFreeText.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { DemographicStatRole } from './demographicRoles';
+
+/** Roles that benefit from free-text / CSV canonicalization */
+const FREE_TEXT_ROLES = new Set<DemographicStatRole>(['school', 'major']);
+
+/** Common short forms → preferred display name */
+const SCHOOL_ALIASES: Record<string, string> = {
+    ubc: 'University of British Columbia',
+    'u of bc': 'University of British Columbia',
+    'university of bc': 'University of British Columbia',
+    ubcv: 'University of British Columbia',
+    ubco: 'University of British Columbia Okanagan',
+    sfu: 'Simon Fraser University',
+    uvic: 'University of Victoria',
+    uoft: 'University of Toronto',
+    'u of t': 'University of Toronto',
+    'u of toronto': 'University of Toronto',
+    waterloo: 'University of Waterloo',
+    uwat: 'University of Waterloo',
+};
+
+//check if drop down or free text
+const MAJOR_ALIASES: Record<string, string> = {
+    cs: 'Computer Science',
+    'comp sci': 'Computer Science',
+    'computer sci': 'Computer Science',
+    ee: 'Electrical Engineering',
+};
+
+type CanonList = { byKey: Map<string, string>; loaded: boolean };
+
+const schoolList: CanonList = { byKey: new Map(), loaded: false };
+const majorList: CanonList = { byKey: new Map(), loaded: false };
+
+export function normalizeKey(input: string): string {
+    return input
+        .toLowerCase()
+        .trim()
+        .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+        .replace(/\s+/g, ' ');
+}
+
+function loadCsvNames(filename: 'schools' | 'majors'): Map<string, string> {
+    const filePath = path.join(process.cwd(), 'public', `${filename}.csv`);
+    const text = readFileSync(filePath, 'utf-8');
+    // schools.csv and majors.csv start with a header / note line
+    const lines = text.split('\n').slice(1);
+    const byKey = new Map<string, string>();
+
+    for (let line of lines) {
+        line = line.replaceAll('"', '').trim();
+        if (!line) continue;
+        const key = normalizeKey(line);
+        if (!byKey.has(key)) {
+            byKey.set(key, line);
+        }
+    }
+    return byKey;
+}
+
+function ensureSchoolList(): Map<string, string> {
+    if (!schoolList.loaded) {
+        schoolList.byKey = loadCsvNames('schools');
+        schoolList.loaded = true;
+    }
+    return schoolList.byKey;
+}
+
+function ensureMajorList(): Map<string, string> {
+    if (!majorList.loaded) {
+        majorList.byKey = loadCsvNames('majors');
+        majorList.loaded = true;
+    }
+    return majorList.byKey;
+}
+
+function titleCaseFallback(raw: string): string {
+    const cleaned = raw.trim().replace(/\s+/g, ' ');
+    if (!cleaned) return 'Not specified';
+    return cleaned;
+}
+
+/**
+ * Map a raw answer string to a stable pie-slice label.
+ * For non free-text roles, just clean whitespace / empty → Not specified.
+ */
+export function canonicalizeFreeText(
+    raw: string,
+    role: DemographicStatRole
+): string {
+    const trimmed = raw.trim();
+    if (!trimmed) return 'Not specified';
+
+    if (!FREE_TEXT_ROLES.has(role)) {
+        return trimmed;
+    }
+
+    const key = normalizeKey(trimmed);
+    const aliases = role === 'school' ? SCHOOL_ALIASES : MAJOR_ALIASES;
+    if (aliases[key]) return aliases[key];
+
+    const list = role === 'school' ? ensureSchoolList() : ensureMajorList();
+    const exact = list.get(key);
+    if (exact) return exact;
+
+    // Weak includes match: first CSV entry that contains the key or vice versa
+    for (const [csvKey, display] of list) {
+        if (csvKey.includes(key) || key.includes(csvKey)) {
+            return display;
+        }
+    }
+
+    return titleCaseFallback(trimmed);
+}
+
+/**
+ * Turn one applicant's raw answer into one or more count keys.
+ * - major may be string[]
+ * - empty → ["Not specified"]
+ */
+export function answersToCountKeys(
+    value: unknown,
+    role: DemographicStatRole
+): string[] {
+    if (value == null || value === '') {
+        return ['Not specified'];
+    }
+
+    if (Array.isArray(value)) {
+        const parts = value
+            .map((item) =>
+                typeof item === 'string'
+                    ? canonicalizeFreeText(item, role)
+                    : canonicalizeFreeText(String(item), role)
+            )
+            .filter((s) => s && s !== 'Not specified');
+        return parts.length > 0 ? parts : ['Not specified'];
+    }
+
+    if (typeof value === 'string' || typeof value === 'number') {
+        return [canonicalizeFreeText(String(value), role)];
+    }
+
+    return [canonicalizeFreeText(String(value), role)];
+}

--- a/src/lib/statistics/statsTypes.ts
+++ b/src/lib/statistics/statsTypes.ts
@@ -1,0 +1,99 @@
+import type { DemographicStatRole } from './demographicRoles';
+import { DEMOGRAPHIC_STAT_ROLES } from './demographicRoles';
+
+export type PieSlice = { name: string; value: number; fill: string };
+export type Cohort = 'all' | 'accepted';
+export type ChartsByRole = Partial<Record<DemographicStatRole, PieSlice[]>>;
+
+export type StatsPayload = {
+    datasets?: {
+        all?: ChartsByRole;
+        accepted?: ChartsByRole;
+    };
+    // legacy shape before this change
+    pronouns?: PieSlice[];
+    experience?: PieSlice[];
+    school?: PieSlice[];
+    levelStudy?: PieSlice[];
+};
+
+function getColorByIndex(index: number): string {
+    const colors = [
+        'hsl(220 70% 60%)',
+        'hsl(160 60% 55%)',
+        'hsl(45 85% 65%)',
+        'hsl(320 70% 65%)',
+        'hsl(120 50% 55%)',
+        'hsl(280 65% 65%)',
+        'hsl(15 75% 60%)',
+        'hsl(0 60% 60%)',
+        'hsl(200 60% 60%)',
+        'hsl(60 70% 60%)',
+    ];
+    return colors[index % colors.length];
+}
+
+export function resolveChartsForCohort(
+    payload: StatsPayload | null,
+    cohort: Cohort
+): ChartsByRole {
+    if (!payload) return {};
+
+    if (payload.datasets?.[cohort]) {
+        return payload.datasets[cohort] ?? {};
+    }
+
+    // Legacy blob (pre-rewrite): treat as accepted-only with old keys
+    if (cohort === 'accepted') {
+        return {
+            pronouns: payload.pronouns ?? [],
+            priorHackathons: payload.experience ?? [],
+            school: payload.school ?? [],
+            education: payload.levelStudy ?? [],
+        };
+    }
+
+    return {};
+}
+
+function mergePieSlices(slicesList: PieSlice[][]): PieSlice[] {
+    const totals = new Map<string, number>();
+
+    for (const slices of slicesList) {
+        for (const slice of slices) {
+            totals.set(slice.name, (totals.get(slice.name) ?? 0) + slice.value);
+        }
+    }
+
+    return [...totals.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, value], index) => ({
+            name,
+            value,
+            fill: index === 0 ? '#3730a3' : getColorByIndex(index),
+        }));
+}
+
+/** Merge multiple chart sets by summing counts for matching category names. */
+export function mergeChartsByRole(chartsList: ChartsByRole[]): ChartsByRole {
+    const result: ChartsByRole = {};
+
+    for (const role of DEMOGRAPHIC_STAT_ROLES) {
+        const slicesList = chartsList
+            .map((charts) => charts[role] ?? [])
+            .filter((slices) => slices.length > 0);
+
+        result[role] = slicesList.length > 0 ? mergePieSlices(slicesList) : [];
+    }
+
+    return result;
+}
+
+export function mergeStatsPayloads(
+    payloads: StatsPayload[],
+    cohort: Cohort
+): ChartsByRole {
+    return mergeChartsByRole(
+        payloads.map((payload) => resolveChartsForCohort(payload, cohort))
+    );
+}


### PR DESCRIPTION
## Describe your changes
- Adds buildDemographicStats, demographicRoles, and normalizeFreeText under src/lib/statistics/.
- Generates stats for all applicants and accepted only cohorts.
- Supports 7 demographic roles: pronouns, age, school, education, year of study, major, and prior hackathons.
- Canonicalizes free-text school/major answers via aliases and public/schools.csv / public/majors.csv.
- Groups low-frequency answers into Other when they appear fewer than 2 times.
- Updates /statistics to render charts dynamically from DEMOGRAPHIC_STAT_ROLES.
- Adds an All applicants / Accepted only toggle (no refetch on toggle).
- Shows an empty-state message when a hackathon form is missing a displayRole for a chart.

## Testing steps 
_Regenerate stats for a hackathon with applications_:
curl "http://localhost:3000/api/blob/statistics/fetch?hackathonId=1"
Confirm response includes datasets.all and datasets.accepted with counts per role.

_Verify read route_:
curl "http://localhost:3000/api/blob/statistics/1"
Confirm success: true and data.datasets is present.

_UI — /statistics (as sponsor/admin/owner)_:
Page loads 7 chart cards.
Accepted only is selected by default.
Toggling cohorts updates charts without a new network request.
Accepted slice totals are ≤ all-applicant totals for the same chart.
Cross-hackathon check: regenerate stats for two hackathons with different question IDs but the same displayRole tags; confirm school (and other roles) populate correctly for both.

Free-text normalization: verify school/major aliases (e.g. UBC → University of British Columbia) and that rare answers roll into Other.

## Issue ticket number and link
#216: https://github.com/sfusurge/hacker-portal/issues/216

## Checklist before requesting a review
- [ ✓] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
